### PR TITLE
Use skip lists for faster insertion

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -1,22 +1,25 @@
 module MutableConvexHulls
 
 using PairedLinkedLists
+using PairedLinkedLists: AbstractNode, AbstractList
 
 include("utils.jl")
 include("orientation.jl")
-include("api.jl")
+include("pointlist.jl")
+include("convexhull.jl")
 include("monotonechain.jl")
 include("jarvismarch.jl")
 include("inside.jl")
 include("merge.jl")
 
 export MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull
+export HullList, PointList, HullNode, PointNode
 export addpoint!, mergepoints!, removepoint!
-export HullNode, PointNode, HullNodeIterator, PointNodeIterator, BracketedPointNodeIterator
+export HullNodeIterator, PointNodeIterator
 export monotonechain, lower_monotonechain, upper_monotonechain
 export jarvismarch, lower_jarvismarch, upper_jarvismarch
 export CCW, CW
 export insidehull
-export mergehulls!, mergehulls
+export mergehulls!
 
 end

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -198,7 +198,7 @@ function addpoint!(h::AbstractConvexHull{T}, point::T) where T
         newpointnode = newnode(h.hull.partner, point)
         f = x -> h.sortedby(x.data) > h.sortedby(point)
         insertbefore = getfirst(f, ListNodeIterator(h.hull.partner))
-        isnothing(insertbefore) ? insertnode!(newpointnode, h.hull.partner.tail.prev) : insertnode!(newpointnode, insertbefore.prev)
+        isnothing(insertbefore) ? insertafter!(newpointnode, h.hull.partner.tail.prev) : insertafter!(newpointnode, insertbefore.prev)
     end
     if !insidehull(point, h)    # if the new point is outside the hull, update the convex hull
         if !h.issorted

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -197,6 +197,7 @@ function mergepoints!(h::MutableUpperConvexHull{T}, points::AbstractVector{T}) w
     mergehulls!(h,h2)
     return h
 end
+mergepoints!(h::AbstractConvexHull, points::Matrix) = mergepoints!(h, [(points[i,:]...,) for i=1:size(points,1)])
 
 function removepoint!(h::AbstractConvexHull{T}, node::HullNode{T}) where T
     node.list !== h.hull && throw(ArgumentError("The specified node must belong to the provided convex hull"))

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -182,17 +182,17 @@ function addpoint!(h::AbstractConvexHull{T}, point::T) where T
     return h
 end
 
-function mergepoints!(h::MutableConvexHull{T}, points::T...) where T
+function mergepoints!(h::MutableConvexHull{T}, points::AbstractVector{T}) where T
     h2 = monotonechain(points; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     mergehulls!(h,h2)
     return h
 end
-function mergepoints!(h::MutableLowerConvexHull{T}, points::T...) where T
+function mergepoints!(h::MutableLowerConvexHull{T}, points::AbstractVector{T}) where T
     h2 = lower_monotonechain(points; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     mergehulls!(h,h2)
     return h
 end
-function mergepoints!(h::MutableUpperConvexHull{T}, points::T...) where T
+function mergepoints!(h::MutableUpperConvexHull{T}, points::AbstractVector{T}) where T
     h2 = upper_monotonechain(points; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     mergehulls!(h,h2)
     return h

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -20,7 +20,7 @@ function jarvismarch!(h::AbstractConvexHull{T}, initedge, stop::Union{PointNode{
     end
 
     # use the appropriate check for determining a better option for the next point
-    betterturn(args...) = h.collinear ? iscloserturn(!h.orientation, args...) : isfurtherturn(!h.orientation, args...)
+    betterturn(prevedge,o,a,b) = h.collinear ? iscloserturn(!h.orientation,prevedge,o,a,b) : isfurtherturn(!h.orientation,prevedge,o,a,b)
 
     # perform jarvis march 
     counter = 0

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -142,7 +142,7 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
     
     # perform jarvis march with search that makes use of the sorted nature of the hulls
     counter = 0
-    current = head(mergedhull)
+    current = start
     candidates = [head(x) for x in hulltargets]
     prevedge = H <: MutableUpperConvexHull ? UP : DOWN
     while counter == 0 || current !== stop

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -1,4 +1,4 @@
-function jarvissortedsearch(query::AbstractListNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
+function jarvissortedsearch(query::AbstractNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
     pointslist.len == 0 && throw(ArgumentError("The list of points must not be empty."))
     pointslist.len == 1 && return head(pointslist)
     head(pointslist).data == tail(pointslist).data && throw(ArgumentError("All points in the list are duplicates."))
@@ -17,84 +17,84 @@ function jarvissortedsearch(query::AbstractListNode, prevedge, pointslist::Abstr
     return tail(pointslist)
 end
 
-function jarvisbinarysearch(query::AbstractListNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
-    pointslist.len == 0 && throw(ArgumentError("The list of points must not be empty."))
-    pointslist.len == 1 && return head(pointslist)
-    head(pointslist).data == tail(pointslist).data && throw(ArgumentError("All points in the list are duplicates."))
+# function jarvisbinarysearch(query::PointNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
+#     pointslist.len == 0 && throw(ArgumentError("The list of points must not be empty."))
+#     pointslist.len == 1 && return head(pointslist)
+#     head(pointslist).data == tail(pointslist).data && throw(ArgumentError("All points in the list are duplicates."))
 
-    # initialize interval bounds
-    left = 1
-    right = pointslist.len
-    middle = Int(floor(pointslist.len/2))
-    target = getnode(pointslist, middle)
+#     # initialize interval bounds
+#     left = 1
+#     right = pointslist.len
+#     middle = Int(floor(pointslist.len/2))
+#     target = getnode(pointslist, middle)
 
-    # recursively shrink interval until a tangent is found
-    return jarvisbinarysearchinterval(left, right, middle, target, query, prevedge, pointslist, betterturn)
-end
+#     # recursively shrink interval until a tangent is found
+#     return jarvisbinarysearchinterval(left, right, middle, target, query, prevedge, pointslist, betterturn)
+# end
 
-# Perform binary search in the interval specified by left and right. The middle index and target node are already determined for the interval
-function jarvisbinarysearchinterval(left::Int, right::Int, middle::Int, target::AbstractListNode, query::AbstractListNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
-    left == middle == right && return target
+# # Perform binary search in the interval specified by left and right. The middle index and target node are already determined for the interval
+# function jarvisbinarysearchinterval(left::Int, right::Int, middle::Int, target::AbstractNode, query::PointNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
+#     left == middle == right && return target
 
-    # wrap around the list to get prev/next values for the ends
-    prev = middle == 1 ? tail(pointslist) : target.prev
-    next = middle == pointslist.len ? head(pointslist) : target.next
+#     # wrap around the list to get prev/next values for the ends
+#     prev = middle == 1 ? tail(pointslist) : target.prev
+#     next = middle == pointslist.len ? head(pointslist) : target.next
 
-    # if the query is a duplicate of a hull point, 
-    (query.data == target.data) && return next
-    (query.data == prev.data) && return target
-    (query.data == next.data) && return next.next
+#     # if the query is a duplicate of a hull point, 
+#     (query.data == target.data) && return next
+#     (query.data == prev.data) && return target
+#     (query.data == next.data) && return next.next
 
-    # check if the adjacent nodes represent "better" options than the target one
-    prev_better = betterturn(prevedge, query.data, target.data, prev.data)
-    next_better = betterturn(prevedge, query.data, target.data, next.data)
-    if !prev_better && !next_better # the target is the best choice
-        return target
-    elseif right - left == 1
-        # handle cases when the best point lies "before" the beginning of the list
-        if middle == 1
-            while prev_better
-                target = prev
-                prev = target.prev
-                prev_better = betterturn(prevedge, query.data, target.data, prev.data)
-            end
-            return target
-        end
-        # handle cases when the best point lies "after" the end of the list
-        if middle == pointslist.len
-            while next_better
-                target = next
-                next = target.next
-                next_better = betterturn(prevedge, query.data, target.data, next.data)
-            end
-            return target
-        end
-        # otherwise, pick the better of the two remaining points
-        return prev_better ? prev : next
-    elseif prev_better # explore the left interval
-        (right - left) == 0 && return prev
-        right = middle
-        middle = Int(floor((right - left)/2) + left)
-        idx_change = right - middle
-        for i=1:idx_change
-            target = target.prev
-        end
-    else # explore the right interval
-        (right - left) == 0 && return next
-        left = middle
-        middle = Int(ceil((right - left)/2) + left)
-        idx_change = middle - left
-        for i=1:idx_change
-            target = target.next
-        end
-    end
+#     # check if the adjacent nodes represent "better" options than the target one
+#     prev_better = betterturn(prevedge, query.data, target.data, prev.data)
+#     next_better = betterturn(prevedge, query.data, target.data, next.data)
+#     if !prev_better && !next_better # the target is the best choice
+#         return target
+#     elseif right - left == 1
+#         # handle cases when the best point lies "before" the beginning of the list
+#         if middle == 1
+#             while prev_better
+#                 target = prev
+#                 prev = target.prev
+#                 prev_better = betterturn(prevedge, query.data, target.data, prev.data)
+#             end
+#             return target
+#         end
+#         # handle cases when the best point lies "after" the end of the list
+#         if middle == pointslist.len
+#             while next_better
+#                 target = next
+#                 next = target.next
+#                 next_better = betterturn(prevedge, query.data, target.data, next.data)
+#             end
+#             return target
+#         end
+#         # otherwise, pick the better of the two remaining points
+#         return prev_better ? prev : next
+#     elseif prev_better # explore the left interval
+#         (right - left) == 0 && return prev
+#         right = middle
+#         middle = Int(floor((right - left)/2) + left)
+#         idx_change = right - middle
+#         for i=1:idx_change
+#             target = target.prev
+#         end
+#     else # explore the right interval
+#         (right - left) == 0 && return next
+#         left = middle
+#         middle = Int(ceil((right - left)/2) + left)
+#         idx_change = middle - left
+#         for i=1:idx_change
+#             target = target.next
+#         end
+#     end
 
-    return jarvisbinarysearchinterval(left, right, middle, target, query, prevedge, pointslist, betterturn)
-end
+#     return jarvisbinarysearchinterval(left, right, middle, target, query, prevedge, pointslist, betterturn)
+# end
 
 function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
     mergedhull = h.hull
-    mergedpoints = mergedhull.partner
+    mergedpoints = h.points
     
     # filter out empty hulls
     hulls = filter(x->length(x.hull)>0,[h, others...])
@@ -107,33 +107,22 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
 
     # Set up copies of the hulls that point to the new points list
     hulltargets = [TargetedLinkedList(mergedpoints) for i=1:length(hulls)]
-    for (i, originalhull) in enumerate(hulls)
-        for data in originalhull.hull
-            push!(hulltargets[i], data)
+    for (originalhull,htarget) in zip(hulls,hulltargets)
+        for hullnode in ListNodeIterator(originalhull.hull)
+            push!(htarget, hullnode.data)
+            # addtarget!(tail(htarget), node)
+            tail(htarget).target = hullnode.target
         end
     end
 
     # add points from all hulls into the points list. 
-    remaininghulls = collect(1:length(hulls))
-    pointnodes = [head(x.hull.partner) for x in hulls]
-    currentnode = mergedpoints.head
-    while !isempty(remaininghulls)
-        hullidx = argmin(x->f(pointnodes[x]), remaininghulls)
-        nextnode = pointnodes[hullidx]
-        if nextnode.list !== mergedpoints
-            nextmergednode = newnode(mergedpoints, nextnode.data)
-            insertnode!(nextmergednode, currentnode)
-        end
-        if haspartner(nextnode)
-            targetingnode = getfirst(x->x.data == nextnode.data, ListNodeIterator(hulltargets[hullidx]))
-            addpartner!(targetingnode, currentnode.next)
-            nextnode.list == mergedpoints && removepartner!(nextnode)
-        end
-        currentnode = currentnode.next
-        pointnodes[hullidx] = pointnodes[hullidx].next
-        if attail(pointnodes[hullidx])
-            deleteidx = findfirst(x->x==hullidx, remaininghulls)
-            deleteat!(remaininghulls, deleteidx)
+    for originalhull in hulls
+        if originalhull !== h
+            for pointnode in ListNodeIterator(originalhull.points)
+                pointnode.list = mergedpoints
+                removetarget!(pointnode)
+                push!(mergedpoints, pointnode)
+            end
         end
     end
     
@@ -149,7 +138,7 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
     # add first point to hull
     empty!(mergedhull)
     pushfirst!(mergedhull, start.data)
-    addpartner!(head(mergedhull), start.partner)
+    addtarget!(head(mergedhull), start.target)
     
     # perform jarvis march with search that makes use of the sorted nature of the hulls
     counter = 0
@@ -176,7 +165,7 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
         end
         # add the next node to the hull
         push!(mergedhull, next.data)
-        addpartner!(tail(mergedhull), next.partner)
+        addtarget!(tail(mergedhull), next.target)
         prevedge = next.data .- current.data
         current = next
     end
@@ -184,7 +173,7 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
     # if these are only partial convex hulls (i.e. upper or lower), add the stopping point at the end of the hull
     if H <: Union{MutableUpperConvexHull, MutableLowerConvexHull}
         push!(mergedhull, stop.data)
-        addpartner!(tail(mergedhull), stop.partner)
+        addtarget!(tail(mergedhull), stop.target)
     end
     return h
 end

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -103,7 +103,7 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
 
     # prepare sorting function and orientation test
     f = x -> h.sortedby(x.data)
-    betterturn(args...) = h.collinear ? iscloserturn(!h.orientation, args...) : isfurtherturn(!h.orientation, args...)
+    betterturn(prevedge,o,a,b) = h.collinear ? iscloserturn(!h.orientation,prevedge,o,a,b) : isfurtherturn(!h.orientation,prevedge,o,a,b)
 
     # Set up copies of the hulls that point to the new points list
     hulltargets = [TargetedLinkedList(mergedpoints) for i=1:length(hulls)]

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -18,6 +18,7 @@ function monotonechain!(h::Union{MutableLowerConvexHull, MutableUpperConvexHull}
                         start::PointNode{T} = firstpoint(h),
                         stop::PointNode{T} = lastpoint(h)) where T
     start.list === stop.list === h.points || throw(ArgumentError("The start and stop nodes do not belong to the appropriate list."))
+    @show h.points
     # exclude or include collinear points on the hull
     wrongturn(args...) = h.collinear ? !isorientedturn(h.orientation, args...) : !isshorterturn(h.orientation, args...)
     # perform monotone chain algorithm

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -60,14 +60,11 @@ function monotonechain!(h::MutableConvexHull{T},
     # exclude or include collinear points on the hull
     wrongturn(o,a,b) = h.collinear ? !isorientedturn(h.orientation,o,a,b) : !isshorterturn(h.orientation,o,a,b)
     # obtain the lower convex hull
-    # onlowerhull = fill(false, h.points.len)
     lowerhullidxs = Int[]
     hullnode = h.hull.head
     len = 0
     for (i,node) in enumerate(ListNodeIterator(h.points; rev=buildinreverse(h)))
         while len >= 2 && wrongturn(hullnode.prev.data, hullnode.data, node.data)
-            # removedindex = findlast(onlowerhull)
-            # onlowerhull[removedindex] = false
             pop!(lowerhullidxs)
             hullnode = hullnode.prev
             deletenode!(hullnode.next)
@@ -84,19 +81,10 @@ function monotonechain!(h::MutableConvexHull{T},
                 hullnode = hullnode.next
             end
         end
-        # onlowerhull[i] = i==1 ? false : true
         i !== 1 && push!(lowerhullidxs, i)
         len += 1
     end
 
-    # @show lowerhullidxs
-    # onlowerhull = fill(false, h.points.len)
-    # for lidx in lowerhullidxs
-    #     onlowerhull[lidx] = true
-    # end
-    # reverse!(onlowerhull)
-    # @show onlowerhull
-    # obtain the upper convex hull
     lidx = length(lowerhullidxs)
     len = 1
     for (i,node) in enumerate(ListNodeIterator(h.points; rev=(h.orientation===CCW)))

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -18,9 +18,8 @@ function monotonechain!(h::Union{MutableLowerConvexHull, MutableUpperConvexHull}
                         start::PointNode{T} = firstpoint(h),
                         stop::PointNode{T} = lastpoint(h)) where T
     start.list === stop.list === h.points || throw(ArgumentError("The start and stop nodes do not belong to the appropriate list."))
-    @show h.points
     # exclude or include collinear points on the hull
-    wrongturn(args...) = h.collinear ? !isorientedturn(h.orientation, args...) : !isshorterturn(h.orientation, args...)
+    wrongturn(o,a,b) = h.collinear ? !isorientedturn(h.orientation,o,a,b) : !isshorterturn(h.orientation,o,a,b)
     # perform monotone chain algorithm
     hullnode = hastarget(start) ? start.target : h.hull.head
     len = length(h.points) == 0 || start === firstpoint(h) ? 0 : 1
@@ -59,7 +58,7 @@ function monotonechain!(h::MutableConvexHull{T},
     length(h) > 0 && deletenode!(head(h.hull))    
     length(h) > 0 && deletenode!(tail(h.hull))    
     # exclude or include collinear points on the hull
-    wrongturn(args...) = h.collinear ? !isorientedturn(h.orientation, args...) : !isshorterturn(h.orientation, args...)
+    wrongturn(o,a,b) = h.collinear ? !isorientedturn(h.orientation,o,a,b) : !isshorterturn(h.orientation,o,a,b)
     # obtain the lower convex hull
     onlowerhull = fill(false, h.points.len)
     hullnode = h.hull.head
@@ -115,7 +114,6 @@ function lower_monotonechain(points::AbstractVector{T}; orientation::HullOrienta
     pointslist = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,typeof(sortedby)}()
     addtarget!(hull, pointslist)
-    # push!(pointslist, points...)
     for p in points
         push!(pointslist,p)
     end
@@ -123,13 +121,11 @@ function lower_monotonechain(points::AbstractVector{T}; orientation::HullOrienta
     monotonechain!(h)
     return h
 end
-lower_monotonechain(points::NTuple{N,T}; kwargs...) where {N,T} = lower_monotonechain([points...]; kwargs...)
 
 function upper_monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity) where T
     pointslist = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,typeof(sortedby)}()
     addtarget!(hull, pointslist)
-    # push!(pointslist, points...)
     for p in points
         push!(pointslist,p)
     end
@@ -137,16 +133,13 @@ function upper_monotonechain(points::AbstractVector{T}; orientation::HullOrienta
     monotonechain!(h)
     return h
 end
-upper_monotonechain(points::NTuple{N,T}; kwargs...) where {N,T} = upper_monotonechain([points...]; kwargs...)
 
 function monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity) where T
     pointslist = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,typeof(sortedby)}()
     addtarget!(hull, pointslist)
-    # push!(pointslist, points...)
     h = MutableConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     monotonechain!(h)
     return h
 end
-monotonechain(points::NTuple{N,T}; kwargs...) where {N,T} = monotonechain([points...]; kwargs...)
 

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -1,8 +1,8 @@
-firstpoint(h::Union{MutableConvexHull, MutableLowerConvexHull}) = h.orientation === CCW ? h.hull.partner.head.next : h.hull.partner.tail.prev
-firstpoint(h::MutableUpperConvexHull) =  h.orientation === CCW ? h.hull.partner.tail.prev : h.hull.partner.head.next
+firstpoint(h::Union{MutableConvexHull, MutableLowerConvexHull}) = h.orientation === CCW ? h.points.head.next : h.points.tail.prev
+firstpoint(h::MutableUpperConvexHull) =  h.orientation === CCW ? h.points.tail.prev : h.points.head.next
 
-lastpoint(h::Union{MutableConvexHull, MutableLowerConvexHull}) = h.orientation === CCW ? h.hull.partner.tail.prev : h.hull.partner.head.next
-lastpoint(h::MutableUpperConvexHull) = h.orientation === CCW ? h.hull.partner.head.next : h.hull.partner.tail.prev
+lastpoint(h::Union{MutableConvexHull, MutableLowerConvexHull}) = h.orientation === CCW ? h.points.tail.prev : h.points.head.next
+lastpoint(h::MutableUpperConvexHull) = h.orientation === CCW ? h.points.head.next : h.points.tail.prev
 
 buildinreverse(h::Union{MutableConvexHull, MutableLowerConvexHull}) = h.orientation === CW
 buildinreverse(h::MutableUpperConvexHull) = h.orientation === CCW
@@ -15,28 +15,28 @@ Each node in the list should contain a two-dimensional point, and the nodes are 
 (e.g. by lowest "x" value and by lowest "y" in case of ties, though some other sorting methods may produce valid results).
 """
 function monotonechain!(h::Union{MutableLowerConvexHull, MutableUpperConvexHull},
-                        start::PairedListNode{T} = firstpoint(h),
-                        stop::PairedListNode{T} = lastpoint(h)) where T
-    start.list === stop.list === h.hull.partner || throw(ArgumentError("The start and stop nodes do not belong to the appropriate list."))
+                        start::PointNode{T} = firstpoint(h),
+                        stop::PointNode{T} = lastpoint(h)) where T
+    start.list === stop.list === h.points || throw(ArgumentError("The start and stop nodes do not belong to the appropriate list."))
     # exclude or include collinear points on the hull
     wrongturn(args...) = h.collinear ? !isorientedturn(h.orientation, args...) : !isshorterturn(h.orientation, args...)
     # perform monotone chain algorithm
-    hullnode = haspartner(start) ? start.partner : h.hull.head
-    len = length(h.hull.partner) == 0 || start === firstpoint(h) ? 0 : 1
+    hullnode = hastarget(start) ? start.target : h.hull.head
+    len = length(h.points) == 0 || start === firstpoint(h) ? 0 : 1
     for node in ListNodeIterator(start; rev=buildinreverse(h))
-        if hullnode !== node.partner
+        if hullnode !== node.target
             while len >= 2 && wrongturn(hullnode.prev.data, hullnode.data, node.data)
                 hullnode = hullnode.prev
                 deletenode!(hullnode.next)
                 len -= 1
             end
         end
-        if !haspartner(node) # avoid overwriting the partners for points already on the hull
-            insertnode!(newnode(h.hull, node.data), hullnode)
+        if !hastarget(node) # avoid overwriting the targets for points already on the hull
+            insertafter!(newnode(h.hull, node.data), hullnode)
             hullnode = hullnode.next
-            addpartner!(hullnode, node)
+            addtarget!(hullnode, node)
         else
-            hullnode = node.partner
+            hullnode = node.target
         end
         node === stop && break
         len += 1
@@ -52,18 +52,18 @@ Each node in the list should contain a two-dimensional point, and the nodes are 
 (e.g. by lowest "x" value and by lowest "y" in case of ties, though some other sorting methods may produce valid results).
 """
 function monotonechain!(h::MutableConvexHull{T},
-                        start::PairedListNode{T} = firstpoint(h),
-                        stop::PairedListNode{T} = lastpoint(h)) where T
+                        start::PointNode{T} = firstpoint(h),
+                        stop::PointNode{T} = lastpoint(h)) where T
     # remove extreme points from the hull (allows them to switch ends in the case of certain deletions)
     length(h) > 0 && deletenode!(head(h.hull))    
     length(h) > 0 && deletenode!(tail(h.hull))    
     # exclude or include collinear points on the hull
     wrongturn(args...) = h.collinear ? !isorientedturn(h.orientation, args...) : !isshorterturn(h.orientation, args...)
     # obtain the lower convex hull
-    onlowerhull = fill(false, h.hull.partner.len)
+    onlowerhull = fill(false, h.points.len)
     hullnode = h.hull.head
     len = 0
-    for (i,node) in enumerate(ListNodeIterator(h.hull.partner; rev=buildinreverse(h)))
+    for (i,node) in enumerate(ListNodeIterator(h.points; rev=buildinreverse(h)))
         while len >= 2 && wrongturn(hullnode.prev.data, hullnode.data, node.data)
             removedindex = findlast(onlowerhull)
             onlowerhull[removedindex] = false
@@ -71,12 +71,12 @@ function monotonechain!(h::MutableConvexHull{T},
             deletenode!(hullnode.next)
             len -= 1
         end
-        if !haspartner(node) # avoid overwriting the partners for points already on the hull
-            insertnode!(newnode(h.hull, node.data), hullnode)
+        if !hastarget(node) # avoid overwriting the targets for points already on the hull
+            insertafter!(newnode(h.hull, node.data), hullnode)
             hullnode = hullnode.next
-            addpartner!(hullnode, node)
+            addtarget!(hullnode, node)
         else
-            if node.partner != hullnode.next
+            if node.target != hullnode.next
                 continue
             else
                 hullnode = hullnode.next
@@ -89,18 +89,18 @@ function monotonechain!(h::MutableConvexHull{T},
     reverse!(onlowerhull)
     # obtain the upper convex hull
     len = 1
-    for (node, islower) in zip(ListNodeIterator(h.hull.partner; rev=(h.orientation===CCW)), onlowerhull)
+    for (node, islower) in zip(ListNodeIterator(h.points; rev=(h.orientation===CCW)), onlowerhull)
         islower && continue
         while len >= 2 && wrongturn(hullnode.prev.data, hullnode.data, node.data)
             hullnode = hullnode.prev
             deletenode!(hullnode.next)
             len -= 1
         end
-        if !haspartner(node) # avoid overwriting the partners for points already on the hull
+        if !hastarget(node) # avoid overwriting the targets for points already on the hull
             addnode = newnode(h.hull, node.data)
-            insertnode!(addnode, hullnode)
+            insertafter!(addnode, hullnode)
             hullnode = hullnode.next
-            addpartner!(hullnode, node)
+            addtarget!(hullnode, node)
         else
             hullnode = hullnode.next
         end
@@ -110,34 +110,40 @@ function monotonechain!(h::MutableConvexHull{T},
     return h
 end
 
-function lower_monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity, presorted::Bool = false) where T
-    sortedpoints = presorted ? points : sort(points; by = sortedby)
-    pointslist = PairedLinkedList{T}(sortedpoints...)
-    hull = PairedLinkedList{T}()
-    addpartner!(hull, pointslist)
-    h = MutableLowerConvexHull{T, typeof(sortedby)}(hull, orientation, collinear, sortedby, true)
+function lower_monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity) where T
+    pointslist = PointList{T}(;sortedby=sortedby)
+    hull = HullList{T,typeof(sortedby)}()
+    addtarget!(hull, pointslist)
+    # push!(pointslist, points...)
+    for p in points
+        push!(pointslist,p)
+    end
+    h = MutableLowerConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     monotonechain!(h)
     return h
 end
 lower_monotonechain(points::NTuple{N,T}; kwargs...) where {N,T} = lower_monotonechain([points...]; kwargs...)
 
-function upper_monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity, presorted::Bool = false) where T
-    sortedpoints = presorted ? points : sort(points; by = sortedby)
-    pointslist = PairedLinkedList{T}(sortedpoints...)
-    hull = PairedLinkedList{T}()
-    addpartner!(hull, pointslist)
-    h = MutableUpperConvexHull{T, typeof(sortedby)}(hull, orientation, collinear, sortedby, true)
+function upper_monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity) where T
+    pointslist = PointList{T}(;sortedby=sortedby)
+    hull = HullList{T,typeof(sortedby)}()
+    addtarget!(hull, pointslist)
+    # push!(pointslist, points...)
+    for p in points
+        push!(pointslist,p)
+    end
+    h = MutableUpperConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     monotonechain!(h)
     return h
 end
 upper_monotonechain(points::NTuple{N,T}; kwargs...) where {N,T} = upper_monotonechain([points...]; kwargs...)
 
-function monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity, presorted::Bool = false) where T
-    sortedpoints = presorted ? points : sort(points; by = sortedby)
-    pointslist = PairedLinkedList{T}(sortedpoints...)
-    hull = PairedLinkedList{T}()
-    addpartner!(hull, pointslist)
-    h = MutableConvexHull{T, typeof(sortedby)}(hull, orientation, collinear, sortedby, true)
+function monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity) where T
+    pointslist = PointList{T}(;sortedby=sortedby)
+    hull = HullList{T,typeof(sortedby)}()
+    addtarget!(hull, pointslist)
+    # push!(pointslist, points...)
+    h = MutableConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     monotonechain!(h)
     return h
 end

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -44,19 +44,27 @@ function isvalidturn(orientation::HullOrientation, condition::Function, oa, ob)
     oriented = orientation === CCW ? (cp >= 0) : (cp <= 0)
     return oriented && condition(cp, oa, ob)
 end
-isvalidturn(orientation::HullOrientation, condition::Function, o, a, b) = isvalidturn(orientation, condition, a .- o, b .- o)
+isvalidturn(orientation::HullOrientation, condition::Function, o, a, b) = isvalidturn(orientation, condition, (a[1] - o[1], a[2] - o[2]), (b[1] - o[1], b[2] - o[2]))
 
 # colinear vectors will always yield `true`
-isorientedturn(orientation::HullOrientation, args...) = isvalidturn(orientation, (cp,v1,v2)->true, args...)
+isorientedturn(orientation::HullOrientation, oa, ob) = isvalidturn(orientation, (cp,v1,v2)->true, oa, ob)
+isorientedturn(orientation::HullOrientation, o, a, b) = isorientedturn(orientation, (a[1] - o[1], a[2] - o[2]), (b[1] - o[1], b[2] - o[2]))
+
 
 # colinear vectors will only yield `true` if they are aligned (dot product > 0). This is typically only useful with sorted points
-isalignedturn(orientation, args...) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : isaligned(oa,ob)), args...)
+isalignedturn(orientation, oa, ob) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : isaligned(oa,ob)), oa, ob)
+isalignedturn(orientation, o, a, b) = isalignedturn(orientation, (a[1] - o[1], a[2] - o[2]), (b[1] - o[1], b[2] - o[2]))
+
 
 # colinear vectors will only yield `true` if the second is shorter than the first. This is typically only useful with sorted points
-isshorterturn(orientation, args...) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : sum(abs2,oa) > sum(abs2,ob)), args...)
+isshorterturn(orientation, oa, ob) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : sum(abs2,oa) > sum(abs2,ob)), oa, ob)
+isshorterturn(orientation, o, a, b) = isshorterturn(orientation, (a[1] - o[1], a[2] - o[2]), (b[1] - o[1], b[2] - o[2]))
+
 
 # colinear vectors will only yield 'true' if they are aligned and if the second vector moves less than the first (relative to the direction of the previous edge)
-iscloserturn(orientation, prevedge, args...) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : isalignedcloser(orientation,prevedge,oa,ob)), args...)
+iscloserturn(orientation, prevedge, oa, ob) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : isalignedcloser(orientation,prevedge,oa,ob)), oa, ob)
+iscloserturn(orientation, prevedge, o, a, b) = iscloserturn(orientation, prevedge, (a[1] - o[1], a[2] - o[2]), (b[1] - o[1], b[2] - o[2]))
 
 # colinear vectors will only yield 'true' if they are aligned and if the second vector moves further than the first (relative to the direction of the previous edge)
-isfurtherturn(orientation, prevedge, args...) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : isalignedfurther(orientation,prevedge,oa,ob)), args...)
+isfurtherturn(orientation, prevedge, oa, ob) = isvalidturn(orientation, (cp, oa, ob) -> (cp != 0 ? true : isalignedfurther(orientation,prevedge,oa,ob)), oa, ob)
+isfurtherturn(orientation, prevedge, o, a, b) = isfurtherturn(orientation, prevedge, (a[1] - o[1], a[2] - o[2]), (b[1] - o[1], b[2] - o[2]))

--- a/src/pointlist.jl
+++ b/src/pointlist.jl
@@ -1,0 +1,173 @@
+using PairedLinkedLists: AbstractPairedListNode, AbstractPairedSkipNode, AbstractPairedLinkedList, AbstractPairedSkipList
+
+abstract type AbstractHullNode{T,L,F} <: AbstractPairedListNode{T,L} end
+# abstract type AbstractPointNode{T,L} <: AbstractPairedSkipNode{T,L} end
+
+abstract type AbstractHullList{T,F} <: AbstractPairedLinkedList{T} end
+abstract type AbstractPointList{T,R,N,F} <: AbstractPairedSkipList{T,F} end
+
+
+mutable struct PointNode{T,L<:AbstractPointList{T},N<:AbstractHullNode{T}} <: AbstractPairedSkipNode{T,L}
+    list::L
+    data::T
+    prev::PointNode{T,L,N}
+    next::PointNode{T,L,N}
+    up::PointNode{T,L,N}
+    down::PointNode{T,L,N}
+    target::Union{N,PointNode{T,L,N}}
+    function PointNode{T,L,N}(list::L) where {T,L<:AbstractPointList{T},N<:AbstractHullNode{T}}
+        node = new{T,L,N}(list)
+        node.next = node
+        node.prev = node
+        node.target = node
+        node.up = node
+        node.down = node
+        return node
+    end
+    function PointNode{T,L,N}(list::L, data) where {T,L<:AbstractPointList{T},N<:AbstractHullNode{T}}
+        node = new{T,L,N}(list, data)
+        node.next = node
+        node.prev = node
+        node.up = node
+        node.down = node
+        node.target = node
+        return node
+    end
+end
+
+mutable struct PointList{T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Function} <: AbstractPointList{T,R,N,F}
+    len::Int
+    nlevels::Int
+    skipfactor::Int
+    sortedby::F
+    target::Union{R,PointList{T,R,N,F}}
+    head::PointNode{T,PointList{T,R,N,F},N}
+    tail::PointNode{T,PointList{T,R,N,F},N}
+    top::PointNode{T, PointList{T,R,N,F},N}
+    toptail::PointNode{T, PointList{T,R,N,F}}
+    function PointList{T,R,N,F}(;sortedby::F=identity, skipfactor::Int=2) where {T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Function}
+        l = new{T,R,N,F}(0,1,skipfactor,sortedby)
+        l.target = l
+        l.head = PointNode{T,PointList{T,R,N,F},N}(l)
+        l.tail = PointNode{T,PointList{T,R,N,F},N}(l)
+        l.top = l.head
+        l.toptail = l.tail
+        l.sortedby = sortedby
+        l.skipfactor = skipfactor
+        l.nlevels = 1
+        l.head.next = l.tail
+        l.tail.prev = l.head
+        l.top.next = l.toptail
+        l.toptail.prev = l.top
+        return l
+    end
+    function PointList{T,R,N,F}(target::PointList{T}; sortedby::F=identity, skipfactor::Int=2) where {T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Function}
+        l = new{T,R,N,F}(0,1,skipfactor,sortedby,target)
+        l.head = PointNode{T,PointList{T,R,N,F},N}(l)
+        l.tail = PointNode{T,PointList{T,R,N,F},N}(l)
+        l.top = l.head
+        l.toptail = l.tail
+        l.sortedby = sortedby
+        l.skipfactor = skipfactor
+        l.nlevels = 1
+        l.head.next = l.tail
+        l.tail.prev = l.head
+        l.top.next = l.toptail
+        l.toptail.prev = l.top
+        return l
+    end
+end
+mutable struct HullNode{T,L<:AbstractHullList{T},F<:Function} <: AbstractHullNode{T,L,F}
+    list::L
+    data::T
+    prev::HullNode{T,L,F}
+    next::HullNode{T,L,F}
+    target::Union{HullNode{T,L,F},PointNode{T,PointList{T,L,HullNode{T,L,F},F},HullNode{T,L,F}}}
+    function HullNode{T,L,F}(list::L) where {T,L<:AbstractHullList{T},F<:Function}
+        node = new{T,L,F}(list)
+        node.next = node
+        node.prev = node
+        node.target = node
+        return node
+    end
+    function HullNode{T,L,F}(list::L, data) where {T,L<:AbstractHullList{T},F<:Function}
+        node = new{T,L,F}(list, data)
+        node.next = node
+        node.prev = node
+        node.target = node
+        return node
+    end
+end
+
+mutable struct HullList{T,F<:Function} <: AbstractHullList{T,F}
+    len::Int
+    target::Union{HullList{T,F}, PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}}
+    head::HullNode{T,HullList{T,F},F}
+    tail::HullNode{T,HullList{T,F},F}
+    function HullList{T,F}() where {T,F<:Function}
+        l = new{T,F}(0)
+        l.target = l
+        l.head = HullNode{T,HullList{T,F},F}(l)
+        l.tail = HullNode{T,HullList{T,F},F}(l)
+        l.head.next = l.tail
+        l.tail.prev = l.head
+        return l
+    end
+    function HullList{T,F}(target::PointList{T}) where {T,F<:Function}
+        l = new{T,F}(0, target)
+        l.head = HullNode{T,HullList{T,F},F}(l)
+        l.tail = HullNode{T,HullList{T,F},F}(l)
+        l.head.next = l.tail
+        l.tail.prev = l.head
+        return l
+    end
+end
+
+HullList{T}(;sortedby::F=identity) where {T,F<:Function} = HullList{T,F}()
+function HullList{T,F}(elts...) where {T,F}
+    l = HullList{T,F}()
+    for elt in elts
+        push!(l, elt)
+    end
+    return l
+end
+
+PointList{T}(;sortedby::F=identity, kwargs...) where {T,F<:Function} = PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}(;sortedby=sortedby,kwargs...)
+#  PointList{T,F}() where {T,F<:Function} = PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}()
+function PointList{T,R,N,F}(elts...) where {T,R,N,F}
+    l = PointList{T,R,N,F}()
+    for elt in elts
+        push!(l, elt)
+    end
+    return l
+end
+
+
+
+PairedLinkedLists.nodetype(::Type{HullList{T,F}}) where {T,F} = HullNode{T,HullList{T,F},F}
+PairedLinkedLists.nodetype(::Type{PointList{T,R,N,F}}) where {T,R,N,F} = PointNode{T,PointList{T,R,N,F},N}
+
+function PairedLinkedLists.addtarget!(list::L, target::R) where {L<:Union{HullList, PointList},R<:Union{HullList,PointList}}
+    if hastarget(list)     # remove existing targets
+        removetarget!(list)
+    end
+    if hastarget(target)
+        removetarget!(target)
+    end
+    list.target = target
+    target.target = list
+    return list
+end
+
+function PairedLinkedLists.addtarget!(node::N, target::R) where {N<:Union{HullNode, PointNode},R<:Union{HullNode,PointNode}}
+    node.list.target === target.list || throw(ArgumentError("The provided node must belong to paired list."))
+    if hastarget(node)     # remove existing targets
+        removetarget!(node)
+    end
+    if hastarget(target)
+        removetarget!(target)
+    end
+    node.target = target
+    target.target = node
+    return node
+end

--- a/src/pointlist.jl
+++ b/src/pointlist.jl
@@ -44,7 +44,7 @@ mutable struct PointList{T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Func
     head::PointNode{T,PointList{T,R,N,F},N}
     tail::PointNode{T,PointList{T,R,N,F},N}
     top::PointNode{T, PointList{T,R,N,F},N}
-    toptail::PointNode{T, PointList{T,R,N,F}}
+    toptail::PointNode{T, PointList{T,R,N,F},N}
     function PointList{T,R,N,F}(;sortedby::F=identity, skipfactor::Int=2) where {T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Function}
         l = new{T,R,N,F}(0,1,skipfactor,sortedby)
         l.target = l

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -47,7 +47,7 @@
                 for scoords in splitcoords
                     append!(mergedcoords, scoords)
                     for h in hulls
-                        mergepoints!(h, scoords...)
+                        mergepoints!(h, scoords)
                         @test h == lower_jarvismarch(mergedcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                     end
                 end
@@ -119,7 +119,7 @@
                 for scoords in splitcoords
                     append!(mergedcoords, scoords)
                     for h in hulls
-                        mergepoints!(h, scoords...)
+                        mergepoints!(h, scoords)
                         @test h == upper_jarvismarch(mergedcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                     end
                 end
@@ -191,7 +191,7 @@
                 for scoords in splitcoords
                     append!(mergedcoords, scoords)
                     for h in hulls
-                        mergepoints!(h, scoords...)
+                        mergepoints!(h, scoords)
                         @test h == jarvismarch(mergedcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                     end
                 end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -6,11 +6,11 @@
     @testset "lower convex hull" begin
         @testset "initialize" begin
             h = MutableLowerConvexHull{eltype(boxcoords)}()
-            @test h.orientation === CCW && h.collinear === false && h.sortedby === identity && h.issorted === false
-            hull = PairedLinkedList{eltype(boxcoords)}()
-            points = PairedLinkedList{eltype(boxcoords)}()
-            addpartner!(hull, points)
-            h2 = MutableLowerConvexHull{eltype(boxcoords), typeof(by)}(hull, CW, true, by, false)
+            @test h.orientation === CCW && h.collinear === false && h.sortedby === identity
+            hull = HullList{eltype(boxcoords)}(;sortedby=by)
+            points = PointList{eltype(boxcoords)}(;sortedby=by)
+            addtarget!(hull, points)
+            h2 = MutableLowerConvexHull{eltype(boxcoords), typeof(by)}(hull, points, CW, true, by)
         end
         @testset "iterate" begin
             
@@ -28,7 +28,7 @@
         @testset "add point" begin
             for j=1:n
                 shuffledcoords = shuffle(boxcoords)
-                hulls = [MutableLowerConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableLowerConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 for (i, coord) in enumerate(shuffledcoords)
                     for h in hulls
                         addpoint!(h, coord)
@@ -42,7 +42,7 @@
                 shuffledcoords = shuffle(boxcoords)
                 len = Int(sqrt(length(boxcoords)))
                 splitcoords = [shuffledcoords[len*(i-1)+1:len*i] for i=1:len]
-                hulls = [MutableLowerConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableLowerConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 mergedcoords = eltype(boxcoords)[]
                 for scoords in splitcoords
                     append!(mergedcoords, scoords)
@@ -56,7 +56,7 @@
         @testset "remove point" begin
             for j=1:n
                 shuffledcoords = shuffle(boxcoords)
-                hulls = [MutableLowerConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableLowerConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 for h in hulls
                     for coord in shuffledcoords
                         addpoint!(h, coord)
@@ -67,7 +67,7 @@
                     removeddata = shuffledcoords[removeidx]
                     deleteat!(shuffledcoords, removeidx)
                     for h in hulls
-                        removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.partner)))
+                        removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.target)))
                         @test h == lower_jarvismarch(shuffledcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                     end
                 end
@@ -78,11 +78,11 @@
     @testset "upper convex hull" begin
         @testset "initialize" begin
             h = MutableUpperConvexHull{eltype(boxcoords)}()
-            @test h.orientation === CCW && h.collinear === false && h.sortedby === identity && h.issorted === false
-            hull = PairedLinkedList{eltype(boxcoords)}()
-            points = PairedLinkedList{eltype(boxcoords)}()
-            addpartner!(hull, points)
-            h2 = MutableUpperConvexHull{eltype(boxcoords), typeof(by)}(hull, CW, true, by, false)
+            @test h.orientation === CCW && h.collinear === false && h.sortedby === identity
+            hull = HullList{eltype(boxcoords)}(;sortedby=by)
+            points = PointList{eltype(boxcoords)}(;sortedby=by)
+            addtarget!(hull, points)
+            h2 = MutableUpperConvexHull{eltype(boxcoords), typeof(by)}(hull, points, CW, true, by)
         end
         @testset "iterate" begin
             
@@ -100,7 +100,7 @@
         @testset "add point" begin
             for j=1:n
                 shuffledcoords = shuffle(boxcoords)
-                hulls = [MutableUpperConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableUpperConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 for (i, coord) in enumerate(shuffledcoords)
                     for h in hulls
                         addpoint!(h, coord)
@@ -114,7 +114,7 @@
                 shuffledcoords = shuffle(boxcoords)
                 len = Int(sqrt(length(boxcoords)))
                 splitcoords = [shuffledcoords[len*(i-1)+1:len*i] for i=1:len]
-                hulls = [MutableUpperConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableUpperConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 mergedcoords = eltype(boxcoords)[]
                 for scoords in splitcoords
                     append!(mergedcoords, scoords)
@@ -128,7 +128,7 @@
         @testset "remove point" begin
             for j=1:n
                 shuffledcoords = shuffle(boxcoords)
-                hulls = [MutableUpperConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableUpperConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 for h in hulls
                     for coord in shuffledcoords
                         addpoint!(h, coord)
@@ -139,7 +139,7 @@
                     removeddata = shuffledcoords[removeidx]
                     deleteat!(shuffledcoords, removeidx)
                     for h in hulls
-                        removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.partner)))
+                        removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.target)))
                         @test h == upper_jarvismarch(shuffledcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                     end
                 end
@@ -150,11 +150,11 @@
     @testset "convex hull" begin
         @testset "initialize" begin
             h = MutableConvexHull{eltype(boxcoords)}()
-            @test h.orientation === CCW && h.collinear === false && h.sortedby === identity && h.issorted === false
-            hull = PairedLinkedList{eltype(boxcoords)}()
-            points = PairedLinkedList{eltype(boxcoords)}()
-            addpartner!(hull, points)
-            h2 = MutableConvexHull{eltype(boxcoords), typeof(by)}(hull, CW, true, by, false)
+            @test h.orientation === CCW && h.collinear === false && h.sortedby === identity
+            hull = HullList{eltype(boxcoords)}(;sortedby=by)
+            points = PointList{eltype(boxcoords)}(;sortedby=by)
+            addtarget!(hull, points)
+            h2 = MutableConvexHull{eltype(boxcoords), typeof(by)}(hull, points, CW, true, by)
         end
         @testset "iterate" begin
             
@@ -172,7 +172,7 @@
         @testset "add point" begin
             for j=1:n
                 shuffledcoords = shuffle(boxcoords)
-                hulls = [MutableConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 for (i, coord) in enumerate(shuffledcoords)
                     for h in hulls
                         addpoint!(h, coord)
@@ -186,7 +186,7 @@
                 shuffledcoords = shuffle(boxcoords)
                 len = Int(sqrt(length(boxcoords)))
                 splitcoords = [shuffledcoords[len*(i-1)+1:len*i] for i=1:len]
-                hulls = [MutableConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 mergedcoords = eltype(boxcoords)[]
                 for scoords in splitcoords
                     append!(mergedcoords, scoords)
@@ -200,7 +200,7 @@
         @testset "remove point" begin
             for j=1:n
                 shuffledcoords = shuffle(boxcoords)
-                hulls = [MutableConvexHull{eltype(shuffledcoords)}(o, c, f, s) for o in [CCW,CW] for c in [false,true] for f in [identity, by] for s in [false,true]]
+                hulls = [MutableConvexHull{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
                 for h in hulls
                     for coord in shuffledcoords
                         addpoint!(h, coord)
@@ -211,7 +211,7 @@
                     removeddata = shuffledcoords[removeidx]
                     deleteat!(shuffledcoords, removeidx)
                     for h in hulls
-                        removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.partner)))
+                        removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.target)))
                         @test h == jarvismarch(shuffledcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                     end
                 end

--- a/test/test_monotonechain.jl
+++ b/test/test_monotonechain.jl
@@ -9,54 +9,54 @@
     @testset "Lower Monotone Chain" begin
         # standard-sorted coords
         lower = lower_monotonechain(boxcoords) # ; orientation = CCW, collinear = false
-        @test collect(lower.hull) == collect(lower_monotonechain(boxcoords; presorted=true).hull) == [first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords)]
+        @test collect(lower.hull) == collect(lower_monotonechain(boxcoords).hull) == [first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords)]
         @test collect(lower_monotonechain(boxcoords; orientation=CW).hull) == reverse(collect(lower.hull))
         lowercollinear = lower_monotonechain(boxcoords; collinear = true)
-        @test collect(lowercollinear.hull) == collect(lower_monotonechain(boxcoords; collinear=true, presorted=true).hull) == [[(i,first(jrange)) for i in irange]..., [(last(irange), j) for j in jrange[2:end]]...]
+        @test collect(lowercollinear.hull) == collect(lower_monotonechain(boxcoords; collinear=true).hull) == [[(i,first(jrange)) for i in irange]..., [(last(irange), j) for j in jrange[2:end]]...]
         @test collect(lower_monotonechain(boxcoords; orientation=CW, collinear=true).hull) == reverse(collect(lowercollinear.hull))
 
         # alternate-sorting coords
         lower2 = lower_monotonechain(boxcoords; sortedby=by) # ; orientation = CCW, collinear = false
-        @test collect(lower2.hull) == [(first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2])] != collect(lower_monotonechain(boxcoords; presorted=true, sortedby=by).hull)
+        @test collect(lower2.hull) == [(first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2])]
         @test collect(lower_monotonechain(boxcoords; orientation=CW, sortedby=by).hull) == reverse(collect(lower2.hull))
         lowercollinear2 = lower_monotonechain(boxcoords; collinear=true, sortedby=by)
-        @test collect(lowercollinear2.hull) == [[(first(jrange),i) for i in reverse(irange)]..., [(j,first(irange)) for j in jrange[2:end]]...] != collect(lower_monotonechain(boxcoords; collinear=true, presorted=true, sortedby=by).hull)
+        @test collect(lowercollinear2.hull) == [[(first(jrange),i) for i in reverse(irange)]..., [(j,first(irange)) for j in jrange[2:end]]...]
         @test collect(lower_monotonechain(boxcoords; orientation=CW, collinear=true, sortedby=by).hull) == reverse(collect(lowercollinear2.hull))
     end
 
     @testset "Upper Monotone Chain" begin
         # standard-sorted coords
         upper = upper_monotonechain(boxcoords) # ; orientation = CCW, collinear = false
-        @test collect(upper.hull) == collect(upper_monotonechain(boxcoords; presorted=true).hull) == [last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords)]
+        @test collect(upper.hull) == collect(upper_monotonechain(boxcoords).hull) == [last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords)]
         @test collect(upper_monotonechain(boxcoords; orientation=CW).hull) == reverse(collect(upper.hull))
         uppercollinear = upper_monotonechain(boxcoords; collinear = true)
-        @test collect(uppercollinear.hull) == collect(upper_monotonechain(boxcoords; collinear=true, presorted=true).hull) == [[(i,last(jrange)) for i in reverse(irange)]..., [(first(irange), j) for j in reverse(jrange)[2:end]]...]
+        @test collect(uppercollinear.hull) == collect(upper_monotonechain(boxcoords; collinear=true).hull) == [[(i,last(jrange)) for i in reverse(irange)]..., [(first(irange), j) for j in reverse(jrange)[2:end]]...]
         @test collect(upper_monotonechain(boxcoords; orientation=CW, collinear=true).hull) == reverse(collect(uppercollinear.hull))
 
         # alternate-sorting coords
         upper2 = upper_monotonechain(boxcoords; sortedby=by) # ; orientation = CCW, collinear = false
-        @test collect(upper2.hull) == [(last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2])] != collect(upper_monotonechain(boxcoords; presorted=true, sortedby=by).hull)
+        @test collect(upper2.hull) == [(last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2])]
         @test collect(upper_monotonechain(boxcoords; orientation=CW, sortedby=by).hull) == reverse(collect(upper2.hull))
         uppercollinear2 = upper_monotonechain(boxcoords; collinear=true, sortedby=by)
-        @test collect(uppercollinear2.hull) == [[(last(jrange),i) for i in irange]..., [(j,last(irange)) for j in reverse(jrange)[2:end]]...] != collect(upper_monotonechain(boxcoords; collinear=true, presorted=true, sortedby=by).hull)
+        @test collect(uppercollinear2.hull) == [[(last(jrange),i) for i in irange]..., [(j,last(irange)) for j in reverse(jrange)[2:end]]...]
         @test collect(upper_monotonechain(boxcoords; orientation=CW, collinear=true, sortedby=by).hull) == reverse(collect(uppercollinear2.hull))
     end
 
     @testset "Full Monotone Chain" begin
         # standard-sorted coords
         hull = monotonechain(boxcoords) # ; orientation = CCW, collinear = false
-        @test collect(hull.hull) == collect(monotonechain(boxcoords; presorted=true).hull) == [first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2])]
+        @test collect(hull.hull) == collect(monotonechain(boxcoords).hull) == [first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2])]
         @test collect(monotonechain(boxcoords; orientation=CW).hull) == reverse(circshift(collect(hull.hull),Int(length(hull.hull)/2-1))) 
         hullcollinear = monotonechain(boxcoords; collinear = true)
-        @test collect(hullcollinear.hull) == collect(monotonechain(boxcoords; collinear=true, presorted=true).hull) == [[(i,first(jrange)) for i in irange]..., [(last(irange), j) for j in jrange[2:end]]..., [(i,last(jrange)) for i in reverse(irange)[2:end]]..., [(first(irange), j) for j in reverse(jrange)[2:end-1]]...]
+        @test collect(hullcollinear.hull) == collect(monotonechain(boxcoords; collinear=true).hull) == [[(i,first(jrange)) for i in irange]..., [(last(irange), j) for j in jrange[2:end]]..., [(i,last(jrange)) for i in reverse(irange)[2:end]]..., [(first(irange), j) for j in reverse(jrange)[2:end-1]]...]
         @test collect(monotonechain(boxcoords; orientation=CW, collinear=true).hull) == reverse(circshift(collect(hullcollinear.hull), Int(length(hullcollinear.hull)/2)-1))
 
         # alternate-sorting coords
         hull2 = monotonechain(boxcoords; sortedby=by) # ; orientation = CCW, collinear = false
-        @test collect(hull2.hull) == [(first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords)] != collect(monotonechain(boxcoords; presorted=true, sortedby=by).hull)
+        @test collect(hull2.hull) == [(first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords)]
         @test collect(monotonechain(boxcoords; orientation=CW, sortedby=by).hull) == reverse(circshift(collect(hull2.hull),Int(length(hull2.hull)/2-1))) 
         hullcollinear2 = monotonechain(boxcoords; collinear=true, sortedby=by)
-        @test collect(hullcollinear2.hull) == [[(first(jrange),i) for i in reverse(irange)]..., [(j,first(irange)) for j in jrange[2:end]]..., [(last(jrange),i) for i in irange[2:end]]..., [(j,last(irange)) for j in reverse(jrange)[2:end-1]]...] != collect(monotonechain(boxcoords; collinear=true, presorted=true, sortedby=by).hull)
+        @test collect(hullcollinear2.hull) == [[(first(jrange),i) for i in reverse(irange)]..., [(j,first(irange)) for j in jrange[2:end]]..., [(last(jrange),i) for i in irange[2:end]]..., [(j,last(irange)) for j in reverse(jrange)[2:end-1]]...]
         @test collect(monotonechain(boxcoords; orientation=CW, collinear=true, sortedby=by).hull) == reverse(circshift(collect(hullcollinear2.hull),Int(length(hullcollinear2.hull)/2-1))) 
     end
 end


### PR DESCRIPTION
Use the skip list branch of [PairedLinkedLists.jl](https://github.com/tmcgrath325/PairedLinkedLists.jl/) to get faster insertion time for the "long list" of hull point candidates.