### PR TITLE
Added cache for Chan hulls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MutableConvexHulls"
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
@@ -9,7 +9,7 @@ PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 
 [compat]
 DoubleFloats = "1.4"
-PairedLinkedLists = "0.2.2"
+PairedLinkedLists = "0.2.3"
 julia = "1.7"
 
 [extras]

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -20,8 +20,8 @@ include("jarvismarch.jl")
 include("inside.jl")
 include("merge.jl")
 
-export MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull
-export ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull
+export AbstractConvexHull, MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull
+export AbstractChanConvexHull, ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull
 export HullList, PointList, HullNode, PointNode
 export addpoint!, mergepoints!, removepoint!
 export HullNodeIterator, PointNodeIterator

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -1,11 +1,55 @@
 abstract type AbstractChanConvexHull{T} <: AbstractConvexHull{T} end
 
+# for debugging
+struct ChanHullCache{T}
+    data::Vector{T}
+    subhulls::Vector{Int}
+    removed::Vector{Bool}
+end
+
+ChanHullCache{T}() where T = ChanHullCache{T}(T[],Int[],Bool[])
+
+pushcache!(h::H, cache::ChanHullCache{T}, subhull, data::T, removed) where {T, H<:AbstractChanConvexHull{T}} = begin
+    shullidx = findfirst(sh -> sh === subhull, h.subhulls)
+    push!(cache.data, data)
+    push!(cache.subhulls, shullidx)
+    push!(cache.removed, removed)
+end
+
+pushcache!(h::H, cache::ChanHullCache{T}, subhull, data::AbstractVector{T}, removed) where {T, H<:AbstractChanConvexHull{T}} = begin
+    shullidx = findfirst(sh -> sh === subhull, h.subhulls)
+    len = length(data)
+    append!(cache.data, data)
+    append!(cache.subhulls, fill(shullidx, len))
+    append!(cache.removed, fill(removed, len))
+end
+
+pushcache!(::AbstractChanConvexHull, ::Nothing, subhull, data, removed) = nothing
+
+removecache!(h::AbstractChanConvexHull, cache::ChanHullCache, data, subhull) = begin
+    pushcache!(h, cache, subhull, data, true)
+end
+
+removecache!(::AbstractChanConvexHull, cache::Nothing, data, subhull) = nothing
+
+emptycache!(cache::ChanHullCache) = begin
+    empty!(cache.data)
+    empty!(cache.subhulls)
+    empty!(cache.removed)
+end
+
+emptycache!(::Nothing) = nothing
+
 mutable struct ChanConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
     hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
     subhulls::Vector{MutableConvexHull{T,F}}
     orientation::HullOrientation
     collinear::Bool
     sortedby::F
+    cache::Union{Nothing, ChanHullCache{T}}
+    function ChanConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby, cache=nothing) where {T,F}
+        return new(hull, subhulls, orientation, collinear, sortedby, cache)
+    end
 end
 function ChanConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     subhulls = [MutableConvexHull{T,F}(orientation, collinear, sortedby)]
@@ -20,6 +64,10 @@ mutable struct ChanLowerConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
     orientation::HullOrientation
     collinear::Bool
     sortedby::F
+    cache::Union{Nothing, ChanHullCache{T}}
+    function ChanLowerConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby, cache=nothing) where {T,F}
+        return new(hull, subhulls, orientation, collinear, sortedby, cache)
+    end
 end
 function ChanLowerConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     subhulls = [MutableLowerConvexHull{T,F}(orientation, collinear, sortedby)]
@@ -34,6 +82,10 @@ mutable struct ChanUpperConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
     orientation::HullOrientation
     collinear::Bool
     sortedby::F
+    cache::Union{Nothing, ChanHullCache{T}}
+    function ChanUpperConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby, cache=nothing) where {T,F}
+        new(hull, subhulls, orientation, collinear, sortedby, cache)
+    end
 end
 function ChanUpperConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     subhulls = [MutableUpperConvexHull{T,F}(orientation, collinear, sortedby)]
@@ -46,6 +98,7 @@ function Base.empty!(h::AbstractChanConvexHull)
     empty!(h.hull)
     subhulls = [subhulls[1]]
     empty!(subhulls[1])
+    emptycache!(h.cache)
     return h
 end
 
@@ -62,6 +115,7 @@ function addpoint!(h::AbstractChanConvexHull{T}, point::T) where T
         end
     end
     smallhull = argmin(x->length(x.points),h.subhulls)
+    pushcache!(h, h.cache, smallhull, point, false)
     updatedhull = addpoint!(smallhull, point)[2]
     updatedhull && merge_hull_lists!(h)
     return h, updatedhull
@@ -76,6 +130,7 @@ function mergepoints!(h::AbstractChanConvexHull{T}, points::AbstractVector{T}) w
         end
     end
     smallhull = argmin(x->length(x.points),h.subhulls)
+    pushcache!(h, h.cache, smallhull, points, false)
     mergepoints!(smallhull, points)
     merge_hull_lists!(h)
     return h
@@ -96,5 +151,65 @@ function removepoint!(h::AbstractChanConvexHull{T}, node::PointNode{T}) where T
     shull === nothing && throw(ArgumentError("The specified node must belong to the provided convex hull"))
     updatedhull = removepoint!(shull, node.target)[2]
     updatedhull && merge_hull_lists!(h)
+    removecache!(h, h.cache, node.data, shull)
     return h, updatedhull
+end
+
+
+function copyfromcache(h::H) where {T,H<:AbstractChanConvexHull{T}}
+    @assert !isnothing(h.cache)
+    hcopy = H(h.orientation, h.collinear, h.sortedby)
+    hcopy.cache = ChanHullCache{T}()
+    hcopy.subhulls[1].points.cache = typeof(h.subhulls[1].points.cache)()
+    for i=2:length(h.subhulls)
+        push!(hcopy.subhulls, eltype(h.subhulls)(h.orientation, h.collinear, h.sortedby))
+        hcopy.subhulls[end].points.cache = typeof(h.subhulls[i].points.cache)()
+    end
+    pointstoadd = T[]
+    levelstoadd = Int[]
+    shullcounters = fill(0, length(h.subhulls))
+    currentshullidx = first(h.cache.subhulls)
+    for (i,(point, shullidx, removed)) in enumerate(zip(h.cache.data, h.cache.subhulls, h.cache.removed))
+        if !isempty(pointstoadd) && (shullidx != currentshullidx || removed || i == length(h.cache.data))
+            if isempty(levelstoadd)
+                mergepoints!(hcopy.subhulls[currentshullidx], pointstoadd)
+            else
+                pointstoadd = sort(pointstoadd; by = h.sortedby)
+                @assert pointstoadd == h.subhulls[currentshullidx].points.cache.data[(length(hcopy.subhulls[currentshullidx].points.cache.data)+1):shullcounters[currentshullidx]]
+                @assert levelstoadd == h.subhulls[currentshullidx].points.cache.levels[(length(hcopy.subhulls[currentshullidx].points.cache.levels)+1):shullcounters[currentshullidx]]
+                for (point, level) in zip(pointstoadd, levelstoadd)
+                    PairedLinkedLists.pushskip!(hcopy.subhulls[currentshullidx].points, point, level)
+                    monotonechain!(hcopy.subhulls[currentshullidx])
+                end
+            end
+            pushcache!(hcopy, hcopy.cache, hcopy.subhulls[currentshullidx], pointstoadd, false)
+            merge_hull_lists!(hcopy)
+            empty!(pointstoadd)
+            empty!(levelstoadd)
+        end
+        currentshullidx = shullidx
+        if removed
+            node = getfirst(x -> x.data == point, PointNodeIterator(hcopy.subhulls[shullidx].points.head.next))
+            removepoint!(hcopy, node)
+            shullcounters[shullidx] += 1
+        else
+            push!(pointstoadd, point)
+            if (h.subhulls[shullidx].points.cache !== nothing)
+                push!(levelstoadd, h.subhulls[shullidx].points.cache.levels[shullcounters[shullidx]+1])
+            end
+            shullcounters[shullidx] += 1
+        end
+    end
+    return hcopy
+end
+
+
+function chanhullsidentical(h1::AbstractChanConvexHull, h2::AbstractChanConvexHull)
+    h1.hull == h2. hull || return false
+    for (sh1, sh2) in zip(h1.subhulls, h2.subhulls)
+        sh1 == sh2 || return false
+        sh1.points == sh2.points || return false
+        PairedLinkedLists.skiplistsidentical(sh1.points, sh2.points) || return false
+    end
+    return true
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,7 @@ tests = ["orientation",
          "jarvismarch",
          "convexhull",
          "chanhull",
+         "cache",
          "testcases"
         ]
 

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -1,0 +1,42 @@
+using Random
+using PairedLinkedLists: getnode, SkipListCache
+using MutableConvexHulls: ChanHullCache, chanhullsidentical
+
+function build_random_hull(H::Type{<:AbstractConvexHull}, n::Int=1024, m::Int=4; subhullcaches=true, orientation=CCW, collinear::Bool=false, sortedby=identity)
+    coords = [(rand(), randn()) for i=1:n]
+
+    h = H{eltype(coords)}(orientation, collinear, sortedby)
+    h.cache = ChanHullCache{eltype(coords)}()
+    if subhullcaches
+        h.subhulls[1].points.cache = SkipListCache{eltype(coords)}()
+    end
+    for i=1:Int(ceil(n/m))
+        mergepoints!(h, coords[(i-1)*m+1:min(i*m,n)])
+        popidx = rand(1:length(h.hull))
+        removepoint!(h, getnode(h.hull, popidx))
+    end
+    return h
+end
+
+@testset "cache" begin
+    for H in [ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull]
+        for o in [CCW, CW]
+            for c in [false, true]
+                for sb in [identity, x -> (x[1], -x[2])]
+                    for shcaches in [false, true]
+                        for i=1:10
+                            h = build_random_hull(H; subhullcaches=shcaches, orientation=o, collinear=c, sortedby=sb)
+                            h2 = MutableConvexHulls.copyfromcache(h)
+                            @test h == h2
+                            if shcaches
+                                @test chanhullsidentical(h, h2)
+                            else
+                                @test !chanhullsidentical(h, h2)
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+end


### PR DESCRIPTION
This implements an optional cache for points added to and removed from a Chan Hull, which keeps track of which sub-hull they have been assigned to. This is primarily intended to be used for debugging.

It should not have any performance impact when the cache is not used (the default case).