### PR TITLE
Merge step bugfixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MutableConvexHulls"
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -106,7 +106,7 @@ end
 Base.iterate(h::AbstractChanConvexHull) = iterate(h, h.hull.head.next)
 Base.iterate(h::AbstractChanConvexHull, node::TargetedListNode) = iterate(h.hull, node)
 
-function addpoint!(h::AbstractChanConvexHull{T}, point::T) where T
+function growsubhulls!(h::AbstractChanConvexHull{T}) where T
     npoints = sum(length, h.subhulls)
     while npoints > 3 && length(h.subhulls)^2 < npoints
         push!(h.subhulls, eltype(h.subhulls)(h.orientation, h.collinear, h.sortedby))
@@ -114,6 +114,11 @@ function addpoint!(h::AbstractChanConvexHull{T}, point::T) where T
             h.subhulls[end].points.cache = PairedLinkedLists.SkipListCache{T}()
         end
     end
+    return h
+end
+
+function addpoint!(h::AbstractChanConvexHull{T}, point::T) where T
+    growsubhulls!(h)
     smallhull = argmin(x->length(x.points),h.subhulls)
     pushcache!(h, h.cache, smallhull, point, false)
     updatedhull = addpoint!(smallhull, point)[2]
@@ -122,13 +127,7 @@ function addpoint!(h::AbstractChanConvexHull{T}, point::T) where T
 end
 
 function mergepoints!(h::AbstractChanConvexHull{T}, points::AbstractVector{T}) where T
-    npoints = sum(length, h.subhulls)
-    while npoints > 3 && length(h.subhulls)^2 < npoints
-        push!(h.subhulls, eltype(h.subhulls)(h.orientation, h.collinear, h.sortedby))
-        if (h.subhulls[1].points.cache !== nothing)
-            h.subhulls[end].points.cache = PairedLinkedLists.SkipListCache{T}()
-        end
-    end
+    growsubhulls!(h)
     smallhull = argmin(x->length(x.points),h.subhulls)
     pushcache!(h, h.cache, smallhull, points, false)
     mergepoints!(smallhull, points)

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -51,7 +51,7 @@ function jarvismarch!(hull::Union{AbstractConvexHull{T},AbstractList{T}}, points
                 throw(ErrorException("Jarvis March failed to progress."))
             end
         end
-        next == stop && break                                                       # the stopping point has been reached
+        coordsareequal(next.data, stop.data) && break                               # the stopping point has been reached
         (typeof(pointslist) <: AbstractPointList{T}) && hastarget(next) && break    # the next node to be added already is part of the hull
         # add the next node to the hull
         push!(hull, next.data)

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -125,12 +125,12 @@ function merge_hull_lists!(mergedhull::AbstractList, hulltargets::Vector{<:Abstr
             end
             counter += 1
             for (i, ht) in enumerate(hulltargets)
-                candidates[i] = (current.list === ht &&                                 # If the current point belongs to the list being considered, we already know 
-                                 !(!collinear && targetscollinear[i])) ?                # its candidate point as long as it doesn't contain extraneous collinear points.                                             
-                    (attail(current.next) ? head(ht) : current.next) :                  # TODO: Ambiguous direction (when a subhull is entirely collinear) can cause issues           
-                    jarvissortedsearch(current, prevedge, ht, betterturn)
+                # candidates[i] = (current.list === ht &&                                 # If the current point belongs to the list being considered, we already know 
+                #                  !(!collinear && targetscollinear[i])) ?                # its candidate point as long as it doesn't contain extraneous collinear points.                                             
+                #     (attail(current.next) ? head(ht) : current.next) :                  # TODO: Ambiguous direction (when a subhull is entirely collinear) can cause issues           
+                #     jarvissortedsearch(current, prevedge, ht, betterturn)
                 # candidates[i] = jarvissortedsearch(current, prevedge, ht, betterturn)
-                # candidates[i] = jarvissearch(current, prevedge, ListNodeIterator(ht), betterturn)
+                candidates[i] = jarvissearch(current, prevedge, ListNodeIterator(ht), betterturn)
             end
             next = jarvissearch(current, prevedge, candidates, betterturn)
             if coordsareequal(current.data, next.data)

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -125,12 +125,12 @@ function merge_hull_lists!(mergedhull::AbstractList, hulltargets::Vector{<:Abstr
             end
             counter += 1
             for (i, ht) in enumerate(hulltargets)
-                # candidates[i] = (current.list === ht &&                                 # If the current point belongs to the list being considered, we already know 
-                #                  !(!collinear && targetscollinear[i])) ?                # its candidate point as long as it doesn't contain extraneous collinear points.                                             
-                #     (attail(current.next) ? head(ht) : current.next) :                  # TODO: Ambiguous direction (when a subhull is entirely collinear) can cause issues           
-                #     jarvissortedsearch(current, prevedge, ht, betterturn)
+                candidates[i] = (current.list === ht &&                                 # If the current point belongs to the list being considered, we already know 
+                                 !(!collinear && targetscollinear[i])) ?                # its candidate point as long as it doesn't contain extraneous collinear points.                                             
+                    (attail(current.next) ? head(ht) : current.next) :                  # TODO: Ambiguous direction (when a subhull is entirely collinear) can cause issues           
+                    jarvissortedsearch(current, prevedge, ht, betterturn)
                 # candidates[i] = jarvissortedsearch(current, prevedge, ht, betterturn)
-                candidates[i] = jarvissearch(current, prevedge, ListNodeIterator(ht), betterturn)
+                # candidates[i] = jarvissearch(current, prevedge, ListNodeIterator(ht), betterturn)
             end
             next = jarvissearch(current, prevedge, candidates, betterturn)
             if coordsareequal(current.data, next.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,8 @@ const MCH = MutableConvexHulls
 
 Random.seed!(1234)
 
-tests = ["orientation",
+tests = [
+         "orientation",
          "monotonechain",
          "jarvismarch",
          "convexhull",


### PR DESCRIPTION
Small tweaks to the process for merging hulls to prevent errors.

There is likely a mistake I have made in setting up the `jarvissortedsearch` approach for merging hulls. I believe it should work in theory, but it often leads to getting stuck in a loop of points and exceeding the maximum allowed size for the hull (i.e. the total size of the collection of points).

I have a few ideas for debugging this (like labelling added nodes as ones that should be skipped, checking to see if the errors are all due to floating point precision issues), but will leave things as is for now.