### PR TITLE
Freshen package: bugfixes, API improvements, tests, and docs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.7'
+          - 'min'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,22 +19,22 @@ jobs:
       matrix:
         version:
           - 'min'
-          - 'nightly'
+          - '1'
         os:
           - ubuntu-latest
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
   docs:
@@ -43,10 +43,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,21 +40,18 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-docdeploy@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          show-versioninfo: true
       - run: |
           julia --project=docs -e '
-            using Documenter: DocMeta, doctest
-            using MutableConvexHulls
-            DocMeta.setdocmeta!(MutableConvexHulls, :DocTestSetup, :(using MutableConvexHulls); recursive=true)
-            doctest(MutableConvexHulls)'
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/Manifest-v*.toml
+/docs/Manifest.toml
+/docs/Manifest-v*.toml
 /docs/build/
 /.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -1,20 +1,24 @@
 name = "MutableConvexHulls"
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
-authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 version = "0.2.6"
+authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]
 DoubleFloats = "497a8b3b-efae-58df-a0af-a86822472b78"
 PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 
 [compat]
+Aqua = "0.8"
 DoubleFloats = "1.4"
 PairedLinkedLists = "0.2.3"
+Random = "1"
+Test = "1"
 julia = "1.7"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "Aqua"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MutableConvexHulls"
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ ExplicitImports = "1.15"
 PairedLinkedLists = "0.3"
 Random = "1"
 Test = "1"
-julia = "1.7"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 Aqua = "0.8"
 DoubleFloats = "1.4"
 ExplicitImports = "1.15"
+OffsetArrays = "1"
 PairedLinkedLists = "0.3"
 Random = "1"
 Test = "1"
@@ -19,8 +20,9 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Aqua", "ExplicitImports"]
+test = ["Test", "Random", "Aqua", "ExplicitImports", "OffsetArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MutableConvexHulls"
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -10,15 +10,17 @@ PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 [compat]
 Aqua = "0.8"
 DoubleFloats = "1.4"
-PairedLinkedLists = "0.2.3"
+ExplicitImports = "1.15"
+PairedLinkedLists = "0.3"
 Random = "1"
 Test = "1"
 julia = "1.7"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Aqua"]
+test = ["Test", "Random", "Aqua", "ExplicitImports"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ PairedLinkedLists = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 Aqua = "0.8"
 DoubleFloats = "1.4"
 ExplicitImports = "1.15"
+Logging = "1"
 OffsetArrays = "1"
 PairedLinkedLists = "0.3"
 Random = "1"
@@ -20,9 +21,10 @@ julia = "1.10"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "Aqua", "ExplicitImports", "OffsetArrays"]
+test = ["Test", "Random", "Logging", "Aqua", "ExplicitImports", "OffsetArrays"]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,27 @@
 [![Aqua QA](https://juliatesting.github.io/Aqua.jl/dev/assets/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 MutableConvexHulls provides a few types that facilitate the calculation of convex hulls from sets of 2D points, as well as supporting efficient updates to the hull upon addition or removal of points.
+
+## Quick start
+
+```julia
+using MutableConvexHulls
+
+points = [(0.0,0.0), (1.0,0.0), (1.0,1.0), (0.0,1.0), (0.5,0.5)]
+h = monotonechain(points)
+collect(h.hull)   # [(0.0,0.0), (1.0,0.0), (1.0,1.0), (0.0,1.0)]
+
+# Add a point — hull updates in place
+addpoint!(h, (2.0, 0.5))
+collect(h.hull)   # [(0.0,0.0), (1.0,0.0), (2.0,0.5), (1.0,1.0), (0.0,1.0)]
+
+# Membership test (boundary counts as inside when collinear=true)
+(2.0, 0.5) in h   # true
+(0.5, 0.5) in h   # true  (interior point)
+
+# Remove a point by value — hull updates in place
+removepoint!(h, (0.0, 0.0))
+collect(h.hull)   # [(0.0,1.0), (1.0,0.0), (2.0,0.5), (1.0,1.0)]
+```
+
+`jarvismarch` is an alternative constructor with the same interface. Lower and upper hull variants (`lower_monotonechain`, `upper_jarvismarch`, …) are also available.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://tmcgrath325.github.io/MutableConvexHulls.jl/dev/)
 [![Build Status](https://github.com/tmcgrath325/MutableConvexHulls.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tmcgrath325/MutableConvexHulls.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/tmcgrath325/MutableConvexHulls.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/tmcgrath325/MutableConvexHulls.jl)
+[![Aqua QA](https://juliatesting.github.io/Aqua.jl/dev/assets/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 MutableConvexHulls provides a few types that facilitate the calculation of convex hulls from sets of 2D points, as well as supporting efficient updates to the hull upon addition or removal of points.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@
 [![Build Status](https://github.com/tmcgrath325/MutableConvexHulls.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/tmcgrath325/MutableConvexHulls.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/tmcgrath325/MutableConvexHulls.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/tmcgrath325/MutableConvexHulls.jl)
 [![Aqua QA](https://juliatesting.github.io/Aqua.jl/dev/assets/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
+[![version](https://juliahub.com/docs/General/MutableConvexHulls/stable/version.svg)](https://juliahub.com/ui/Packages/General/MutableConvexHulls)
 
-MutableConvexHulls provides a few types that facilitate the calculation of convex hulls from sets of 2D points, as well as supporting efficient updates to the hull upon addition or removal of points.
+MutableConvexHulls provides types and operations for computing and incrementally updating convex hulls of 2-D point sets. It is designed for use cases where points are added or removed one at a time and the hull must remain current after each change.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("MutableConvexHulls")
+```
 
 ## Quick start
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.4"
 manifest_format = "2.0"
-project_hash = "48fa0448bf5b5e1f5aa13df9130e83c9a3c2b2fe"
+project_hash = "54b76d693a1df9c7e7d727ed5727bab8b73e10f7"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -149,7 +149,7 @@ version = "1.11.0"
 
 [[deps.MutableConvexHulls]]
 deps = ["DoubleFloats", "PairedLinkedLists"]
-path = ".."
+path = "/home/tom/Projects/Julia/MutableConvexHulls.jl"
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
 version = "0.4.0"
 
@@ -179,7 +179,7 @@ uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
 version = "0.5.6+0"
 
 [[deps.PairedLinkedLists]]
-path = "../../PairedLinkedLists.jl"
+git-tree-sha1 = "8e79470c4c4512d2756466d946b6987669f82cf0"
 uuid = "7a42b37b-ed3b-477a-9848-3661f53bb718"
 version = "0.3.0"
 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,19 +1,41 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.2"
+julia_version = "1.12.4"
 manifest_format = "2.0"
+project_hash = "48fa0448bf5b5e1f5aa13df9130e83c9a3c2b2fe"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
 
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
@@ -27,6 +49,18 @@ git-tree-sha1 = "2498c3704e9cd26bf586a351473417881676bb2d"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.27.21"
 
+[[deps.DoubleFloats]]
+deps = ["GenericLinearAlgebra", "LinearAlgebra", "Printf", "Quadmath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "341267a7b8db517bef61e704a46f02f2672b3a15"
+uuid = "497a8b3b-efae-58df-a0af-a86822472b78"
+version = "1.9.1"
+
+[[deps.GenericLinearAlgebra]]
+deps = ["LinearAlgebra", "Printf", "Random", "libblastrampoline_jll"]
+git-tree-sha1 = "6a0335feebe8e2b61242f2b4ec165c1b70b83f8a"
+uuid = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
+version = "0.4.0"
+
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
 git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
@@ -36,6 +70,18 @@ version = "0.2.2"
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -43,27 +89,99 @@ git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.3"
 
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
 [[deps.LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "1.0.1"
+
+    [deps.LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [deps.LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[deps.MutableConvexHulls]]
+deps = ["DoubleFloats", "PairedLinkedLists"]
 path = ".."
 uuid = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
-version = "0.1.0"
+version = "0.4.0"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.6+0"
+
+[[deps.PairedLinkedLists]]
+path = "../../PairedLinkedLists.jl"
+uuid = "7a42b37b-ed3b-477a-9848-3661f53bb718"
+version = "0.3.0"
 
 [[deps.Parsers]]
 deps = ["Dates"]
@@ -71,30 +189,85 @@ git-tree-sha1 = "0044b23da09b5608b4ecacb4e5e6c6332f833a7e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.3.2"
 
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Quadmath]]
+deps = ["Compat", "Printf", "Random"]
+git-tree-sha1 = "79cd6923b7e5fdb4130cdb0f6c0038d7f65a9717"
+uuid = "be4d8f0f-7fa4-5f49-b795-2f01399ab2dd"
+version = "1.0.1"
+weakdeps = ["SpecialFunctions"]
+
+    [deps.Quadmath.extensions]
+    QuadmathSpecialFunctionsExt = ["SpecialFunctions"]
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
-deps = ["SHA", "Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.SpecialFunctions]]
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.8.0"
+
+    [deps.SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [deps.SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MutableConvexHulls = "948c7aac-0e5e-4631-af23-7a6bb7a17825"
+
+[compat]
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ makedocs(;
     authors="Tom McGrath <tmcgrath325@gmail.com> and contributors",
     repo="https://github.com/tmcgrath325/MutableConvexHulls.jl/blob/{commit}{path}#{line}",
     sitename="MutableConvexHulls.jl",
+    checkdocs=:exports,
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tmcgrath325.github.io/MutableConvexHulls.jl",
@@ -16,6 +17,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "API Reference" => "api.md",
     ],
 )
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,96 @@
+```@meta
+CurrentModule = MutableConvexHulls
+```
+
+# API Reference
+
+## Hull types
+
+### Abstract types
+
+```@docs
+AbstractConvexHull
+AbstractChanConvexHull
+```
+
+### Full hull
+
+```@docs
+MutableConvexHull
+ChanConvexHull
+```
+
+### Lower hull
+
+```@docs
+MutableLowerConvexHull
+ChanLowerConvexHull
+```
+
+### Upper hull
+
+```@docs
+MutableUpperConvexHull
+ChanUpperConvexHull
+```
+
+## Batch constructors
+
+### Monotone chain
+
+```@docs
+monotonechain
+lower_monotonechain
+upper_monotonechain
+```
+
+### Jarvis march
+
+```@docs
+jarvismarch
+lower_jarvismarch
+upper_jarvismarch
+```
+
+## Incremental point operations
+
+```@docs
+addpoint!
+mergepoints!
+removepoint!
+```
+
+## Merging hulls
+
+```@docs
+mergehulls!
+mergehulls
+```
+
+## Membership testing
+
+```@docs
+insidehull
+```
+
+## Orientation
+
+```@docs
+CCW
+CW
+```
+
+## Node access
+
+Most users iterate a hull directly to obtain vertex values. When you need to work with the
+underlying linked-list nodes — for example, to pass a node to [`removepoint!`](@ref) — use
+the iterators and types below.
+
+```@docs
+MutableConvexHulls.HullNodeIterator
+MutableConvexHulls.PointNodeIterator
+HullList
+PointList
+HullNode
+PointNode
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,14 +1,149 @@
 ```@meta
 CurrentModule = MutableConvexHulls
+DocTestSetup = :(using MutableConvexHulls)
 ```
 
 # MutableConvexHulls
 
-Documentation for [MutableConvexHulls](https://github.com/tmcgrath325/MutableConvexHulls.jl).
+MutableConvexHulls provides types and operations for computing and incrementally updating
+convex hulls of 2-D point sets. It is designed for use cases where points are added or
+removed one at a time and the hull must remain current after each change.
 
-```@index
+## Installation
+
+MutableConvexHulls is a registered Julia package. Install it with:
+
+```julia
+using Pkg
+Pkg.add("MutableConvexHulls")
 ```
 
-```@autodocs
-Modules = [MutableConvexHulls]
+Or in the package manager REPL (`]`):
+
 ```
+pkg> add MutableConvexHulls
+```
+
+## Quick start
+
+Build a hull from a collection of points, then add, query, and remove points incrementally:
+
+```jldoctest quickstart
+julia> h = monotonechain([(0.0, 0.0), (1.0, 0.0), (0.5, 0.5), (1.0, 1.0), (0.0, 1.0)])
+MutableConvexHull{Tuple{Float64, Float64}, typeof(identity)}((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+
+julia> h, expanded = addpoint!(h, (2.0, 0.5));
+
+julia> expanded
+true
+
+julia> collect(h)
+5-element Vector{Tuple{Float64, Float64}}:
+ (0.0, 0.0)
+ (1.0, 0.0)
+ (2.0, 0.5)
+ (1.0, 1.0)
+ (0.0, 1.0)
+
+julia> (2.0, 0.5) in h  # on the boundary
+true
+
+julia> (3.0, 0.0) in h  # outside
+false
+
+julia> h, removed = removepoint!(h, (0.0, 0.0));
+
+julia> removed
+true
+
+julia> collect(h)
+4-element Vector{Tuple{Float64, Float64}}:
+ (0.0, 1.0)
+ (1.0, 0.0)
+ (2.0, 0.5)
+ (1.0, 1.0)
+```
+
+## Concepts
+
+### Full, lower, and upper hulls
+
+Three hull variants are available for each hull family:
+
+- **Full hull** ([`MutableConvexHull`](@ref), [`ChanConvexHull`](@ref)) — the complete convex
+  hull boundary, listed as a closed polygon.
+- **Lower hull** ([`MutableLowerConvexHull`](@ref), [`ChanLowerConvexHull`](@ref)) — the chain
+  of vertices along the bottom boundary, from the leftmost to the rightmost point.
+- **Upper hull** ([`MutableUpperConvexHull`](@ref), [`ChanUpperConvexHull`](@ref)) — the chain
+  of vertices along the top boundary, from the rightmost to the leftmost point.
+
+```jldoctest partialhulls
+julia> pts = [(0.0, 0.0), (1.0, -0.5), (2.0, 0.0), (1.5, 1.0), (0.5, 1.0)];
+
+julia> lower_monotonechain(pts)
+MutableLowerConvexHull{Tuple{Float64, Float64}, typeof(identity)}((0.0, 0.0), (1.0, -0.5), (2.0, 0.0))
+
+julia> upper_monotonechain(pts)
+MutableUpperConvexHull{Tuple{Float64, Float64}, typeof(identity)}((2.0, 0.0), (1.5, 1.0), (0.5, 1.0), (0.0, 0.0))
+```
+
+### `MutableConvexHull` vs `ChanConvexHull`
+
+Both families maintain the same hull and support the same operations, but they use different
+internal representations:
+
+- **`MutableConvexHull`** stores all points in a single sorted linked list. Each `addpoint!`
+  or `removepoint!` call checks whether the new point changes the boundary and, if so,
+  reruns the monotone-chain algorithm over the affected segment. This is efficient for hulls
+  with frequent point removals or small numbers of points.
+
+- **`ChanConvexHull`** distributes points across a vector of `MutableConvexHull` sub-hulls
+  and derives the outer hull by merging their boundaries. Points are never removed from
+  sub-hulls during a removal — instead the sub-hull is recomputed — which makes large
+  batch additions cheaper. Use `ChanConvexHull` when the point set is large and additions
+  dominate.
+
+### Orientation and collinear points
+
+Both families accept two keyword arguments that control how the hull boundary is reported:
+
+- **`orientation`** — `CCW` (default) lists vertices counterclockwise; `CW` lists them
+  clockwise.
+- **`collinear`** — when `false` (default), collinear points on an edge are not included
+  as hull vertices; when `true`, they are.
+
+### Constructors: `monotonechain` vs `jarvismarch`
+
+Two batch constructors build a hull from an existing point collection:
+
+- [`monotonechain`](@ref) uses the [monotone chain algorithm](https://doi.org/10.1016/0020-0190(79)90072-3)
+  and is the recommended default.
+- [`jarvismarch`](@ref) uses the [gift-wrapping (Jarvis march) algorithm](https://en.wikipedia.org/wiki/Gift_wrapping_algorithm).
+
+Both return the same type with the same interface; subsequent incremental operations use
+monotone chain internally regardless of which constructor was used.
+
+### Merging hulls
+
+[`mergehulls!`](@ref) merges one or more hulls into another in place; [`mergehulls`](@ref)
+returns a new hull without mutating its arguments:
+
+```jldoctest merge
+julia> h1 = monotonechain([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)]);
+
+julia> h2 = monotonechain([(2.0, 0.0), (2.0, 1.0), (1.0, 1.0)]);
+
+julia> mergehulls(h1, h2)
+MutableConvexHull{Tuple{Float64, Float64}, typeof(identity)}((0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0))
+```
+
+### Accessing nodes
+
+Iterating a hull directly yields its vertices as values. For finer-grained access to the
+underlying linked-list nodes — for example, to pass a specific node to
+[`removepoint!`](@ref) — use the semi-public iterators
+[`MutableConvexHulls.HullNodeIterator`](@ref) (over [`HullNode`](@ref)s in `h.hull`) and
+[`MutableConvexHulls.PointNodeIterator`](@ref) (over [`PointNode`](@ref)s in `h.points`,
+including interior points).
+
+See the [API Reference](@ref) for the full list of exported functions and types.

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -31,11 +31,17 @@ export AbstractConvexHull, MutableConvexHull, MutableLowerConvexHull, MutableUpp
 export AbstractChanConvexHull, ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull
 export HullList, PointList, HullNode, PointNode
 export addpoint!, mergepoints!, removepoint!
-export HullNodeIterator, PointNodeIterator
 export monotonechain, lower_monotonechain, upper_monotonechain
 export jarvismarch, lower_jarvismarch, upper_jarvismarch
 export CCW, CW
 export insidehull
 export mergehulls, mergehulls!
+
+# `HullNodeIterator` and `PointNodeIterator` expose `HullNode`/`PointNode` field
+# layouts, so they are public rather than exported. The `public` keyword exists
+# only on Julia ≥ 1.11; on the LTS these remain reachable as qualified names.
+@static if VERSION >= v"1.11"
+    eval(Expr(:public, :HullNodeIterator, :PointNodeIterator))
+end
 
 end

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -15,7 +15,7 @@ using PairedLinkedLists: PairedLinkedLists,
                          ListNodeIterator, PairedListNode,
                          TargetedLinkedList, TargetedListNode,
                          addtarget!, athead, attail, deletenode!, hastarget,
-                         head, insertafter!, newnode, nodetype, removetarget!, tail
+                         head, insertafter!, newnode, nodetype, removetarget!, search, tail
 
 include("utils.jl")
 include("orientation.jl")
@@ -36,6 +36,6 @@ export monotonechain, lower_monotonechain, upper_monotonechain
 export jarvismarch, lower_jarvismarch, upper_jarvismarch
 export CCW, CW
 export insidehull
-export mergehulls!
+export mergehulls, mergehulls!
 
 end

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -2,7 +2,7 @@
 MutableConvexHulls.jl provides ways to calculate and update vertex representations of planar [convex polytopes](https://en.wikipedia.org/wiki/Convex_polytope) 
 (i.e. convex hulls). It is intended for use in situations when a convex hull must be updated iteratively with addition or removal of points.
 
-See also [MutableConvexHull](@ref), [LowerMutableConvexHull](@ref), [UpperMutableConvexHull](@ref), [monotonechain](@ref), [addpoint!](@ref), [mergepoints!](@ref), [removepoint!](@ref), 
+See also [MutableConvexHull](@ref), [MutableLowerConvexHull](@ref), [MutableUpperConvexHull](@ref), [monotonechain](@ref), [addpoint!](@ref), [mergepoints!](@ref), [removepoint!](@ref)
 """
 module MutableConvexHulls
 

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -8,11 +8,11 @@ module MutableConvexHulls
 
 using DoubleFloats: DoubleFloats, DoubleFloat
 using PairedLinkedLists: PairedLinkedLists,
-                         AbstractNode, AbstractList, AbstractLinkedList,
+                         AbstractNode, AbstractList,
                          AbstractPairedListNode, AbstractPairedSkipNode,
                          AbstractPairedLinkedList, AbstractPairedSkipList,
                          SkipListCache,
-                         ListNodeIterator, PairedListNode,
+                         ListNodeIterator,
                          TargetedLinkedList, TargetedListNode,
                          addtarget!, athead, attail, deletenode!, hastarget,
                          head, insertafter!, newnode, nodetype, removetarget!, search, tail

--- a/src/MutableConvexHulls.jl
+++ b/src/MutableConvexHulls.jl
@@ -6,9 +6,16 @@ See also [MutableConvexHull](@ref), [LowerMutableConvexHull](@ref), [UpperMutabl
 """
 module MutableConvexHulls
 
-using PairedLinkedLists
-using PairedLinkedLists: AbstractNode, AbstractList
-using DoubleFloats
+using DoubleFloats: DoubleFloats, DoubleFloat
+using PairedLinkedLists: PairedLinkedLists,
+                         AbstractNode, AbstractList, AbstractLinkedList,
+                         AbstractPairedListNode, AbstractPairedSkipNode,
+                         AbstractPairedLinkedList, AbstractPairedSkipList,
+                         SkipListCache,
+                         ListNodeIterator, PairedListNode,
+                         TargetedLinkedList, TargetedListNode,
+                         addtarget!, athead, attail, deletenode!, hastarget,
+                         head, insertafter!, newnode, nodetype, removetarget!, tail
 
 include("utils.jl")
 include("orientation.jl")

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -51,12 +51,12 @@ mutable struct ChanConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
         return new(hull, subhulls, orientation, collinear, sortedby, cache)
     end
 end
-function ChanConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
-    subhulls = [MutableConvexHull{T,F}(orientation, collinear, sortedby)]
+function ChanConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
+    subhulls = [MutableConvexHull{T,F}(; orientation, collinear, sortedby)]
     hull = TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}()
     return ChanConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby)
 end
-ChanConvexHull{T}(orientation::HullOrientation=CCW,collinear::Bool=false,sortedby::F=identity) where {T,F} = ChanConvexHull{T,F}(orientation,collinear,sortedby)
+ChanConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = ChanConvexHull{T,F}(; orientation, collinear, sortedby)
 
 mutable struct ChanLowerConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
     const hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
@@ -69,12 +69,12 @@ mutable struct ChanLowerConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
         return new(hull, subhulls, orientation, collinear, sortedby, cache)
     end
 end
-function ChanLowerConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
-    subhulls = [MutableLowerConvexHull{T,F}(orientation, collinear, sortedby)]
+function ChanLowerConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
+    subhulls = [MutableLowerConvexHull{T,F}(; orientation, collinear, sortedby)]
     hull = TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}()
     return ChanLowerConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby)
 end
-ChanLowerConvexHull{T}(orientation::HullOrientation=CCW,collinear::Bool=false,sortedby::F=identity) where {T,F} = ChanLowerConvexHull{T,F}(orientation,collinear,sortedby)
+ChanLowerConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = ChanLowerConvexHull{T,F}(; orientation, collinear, sortedby)
 
 mutable struct ChanUpperConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
     const hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
@@ -87,12 +87,12 @@ mutable struct ChanUpperConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
         new(hull, subhulls, orientation, collinear, sortedby, cache)
     end
 end
-function ChanUpperConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
-    subhulls = [MutableUpperConvexHull{T,F}(orientation, collinear, sortedby)]
+function ChanUpperConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
+    subhulls = [MutableUpperConvexHull{T,F}(; orientation, collinear, sortedby)]
     hull = TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}()
     return ChanUpperConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby)
 end
-ChanUpperConvexHull{T}(orientation::HullOrientation=CCW,collinear::Bool=false,sortedby::F=identity) where {T,F} = ChanUpperConvexHull{T,F}(orientation,collinear,sortedby)
+ChanUpperConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = ChanUpperConvexHull{T,F}(; orientation, collinear, sortedby)
 
 function Base.empty!(h::AbstractChanConvexHull)
     empty!(h.hull)
@@ -105,7 +105,7 @@ end
 # Deep copy: duplicate each subhull, then rebuild the merged hull and cache so
 # the copy shares no linked-list nodes with `h`.
 function Base.copy(h::H) where {T, H<:AbstractChanConvexHull{T}}
-    hcopy = H(h.orientation, h.collinear, h.sortedby)
+    hcopy = H(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     hcopy.subhulls = [copy(sh) for sh in h.subhulls]
     merge_hull_lists!(hcopy)
     hcopy.cache = h.cache === nothing ? nothing : deepcopy(h.cache)
@@ -119,7 +119,7 @@ Base.iterate(h::AbstractChanConvexHull, node::TargetedListNode) = iterate(h.hull
 function growsubhulls!(h::AbstractChanConvexHull{T}) where T
     npoints = sum(length, h.subhulls)
     while npoints > 3 && length(h.subhulls)^2 < npoints
-        push!(h.subhulls, eltype(h.subhulls)(h.orientation, h.collinear, h.sortedby))
+        push!(h.subhulls, eltype(h.subhulls)(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby))
         if (h.subhulls[1].points.cache !== nothing)
             h.subhulls[end].points.cache = PairedLinkedLists.SkipListCache{T}()
         end
@@ -175,11 +175,11 @@ end
 
 function copyfromcache(h::H) where {T,H<:AbstractChanConvexHull{T}}
     @assert !isnothing(h.cache)
-    hcopy = H(h.orientation, h.collinear, h.sortedby)
+    hcopy = H(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     hcopy.cache = ChanHullCache{T}()
     hcopy.subhulls[1].points.cache = typeof(h.subhulls[1].points.cache)()
     for i=2:length(h.subhulls)
-        push!(hcopy.subhulls, eltype(h.subhulls)(h.orientation, h.collinear, h.sortedby))
+        push!(hcopy.subhulls, eltype(h.subhulls)(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby))
         hcopy.subhulls[end].points.cache = typeof(h.subhulls[i].points.cache)()
     end
     pointstoadd = T[]

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -102,6 +102,16 @@ function Base.empty!(h::AbstractChanConvexHull)
     return h
 end
 
+# Deep copy: duplicate each subhull, then rebuild the merged hull and cache so
+# the copy shares no linked-list nodes with `h`.
+function Base.copy(h::H) where {T, H<:AbstractChanConvexHull{T}}
+    hcopy = H(h.orientation, h.collinear, h.sortedby)
+    hcopy.subhulls = [copy(sh) for sh in h.subhulls]
+    merge_hull_lists!(hcopy)
+    hcopy.cache = h.cache === nothing ? nothing : deepcopy(h.cache)
+    return hcopy
+end
+
 # Iterating a convex hull returns the data contained in the nodes of its hull list
 Base.iterate(h::AbstractChanConvexHull) = iterate(h, h.hull.head.next)
 Base.iterate(h::AbstractChanConvexHull, node::TargetedListNode) = iterate(h.hull, node)

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -174,7 +174,7 @@ end
 
 
 function copyfromcache(h::H) where {T,H<:AbstractChanConvexHull{T}}
-    @assert !isnothing(h.cache)
+    isnothing(h.cache) && throw(ArgumentError("copyfromcache requires a hull with an initialized cache, but h.cache is nothing"))
     hcopy = H(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     hcopy.cache = ChanHullCache{T}()
     hcopy.subhulls[1].points.cache = typeof(h.subhulls[1].points.cache)()
@@ -192,8 +192,12 @@ function copyfromcache(h::H) where {T,H<:AbstractChanConvexHull{T}}
                 mergepoints!(hcopy.subhulls[currentshullidx], pointstoadd)
             else
                 pointstoadd = sort(pointstoadd; by = h.sortedby)
-                @assert pointstoadd == h.subhulls[currentshullidx].points.cache.data[(length(hcopy.subhulls[currentshullidx].points.cache.data)+1):shullcounters[currentshullidx]]
-                @assert levelstoadd == h.subhulls[currentshullidx].points.cache.levels[(length(hcopy.subhulls[currentshullidx].points.cache.levels)+1):shullcounters[currentshullidx]]
+                # Internal invariant: the points and levels reconstructed for this
+                # subhull must equal those recorded in its skip-list cache. A mismatch
+                # means the cache and skip-list have diverged. Thrown rather than
+                # @assert so the check runs regardless of optimization level.
+                pointstoadd == h.subhulls[currentshullidx].points.cache.data[(length(hcopy.subhulls[currentshullidx].points.cache.data)+1):shullcounters[currentshullidx]] || throw(AssertionError("copyfromcache: reconstructed points disagree with the subhull's skip-list cache"))
+                levelstoadd == h.subhulls[currentshullidx].points.cache.levels[(length(hcopy.subhulls[currentshullidx].points.cache.levels)+1):shullcounters[currentshullidx]] || throw(AssertionError("copyfromcache: reconstructed levels disagree with the subhull's skip-list cache"))
                 for (point, level) in zip(pointstoadd, levelstoadd)
                     PairedLinkedLists.pushskip!(hcopy.subhulls[currentshullidx].points, point, level)
                     monotonechain!(hcopy.subhulls[currentshullidx])

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -1,3 +1,14 @@
+"""
+    AbstractChanConvexHull{T}
+
+Abstract supertype for convex hulls that distribute their points across multiple
+[`MutableConvexHull`](@ref)-style sub-hulls and merge the results.
+
+Concrete subtypes are [`ChanConvexHull`](@ref), [`ChanLowerConvexHull`](@ref), and
+[`ChanUpperConvexHull`](@ref). They support the same incremental operations as their
+`Mutable*` counterparts (`addpoint!`, `mergepoints!`, `removepoint!`, `insidehull`)
+but do not accept [`mergehulls!`](@ref)/[`mergehulls`](@ref).
+"""
 abstract type AbstractChanConvexHull{T} <: AbstractConvexHull{T} end
 
 # for debugging
@@ -56,6 +67,15 @@ function ChanConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool
     hull = TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}()
     return ChanConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby)
 end
+"""
+    h = ChanConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
+
+A full convex hull that distributes its points across multiple [`MutableConvexHull`](@ref)
+sub-hulls and merges them on demand. Supports the same keyword arguments and incremental
+operations as [`MutableConvexHull`](@ref), but does not accept [`mergehulls!`](@ref)/[`mergehulls`](@ref).
+
+See also: [`ChanLowerConvexHull`](@ref), [`ChanUpperConvexHull`](@ref), [`addpoint!`](@ref), [`mergepoints!`](@ref), [`removepoint!`](@ref)
+"""
 ChanConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = ChanConvexHull{T,F}(; orientation, collinear, sortedby)
 
 mutable struct ChanLowerConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
@@ -74,6 +94,16 @@ function ChanLowerConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear:
     hull = TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}()
     return ChanLowerConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby)
 end
+"""
+    h = ChanLowerConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
+
+A lower convex hull that distributes its points across multiple [`MutableLowerConvexHull`](@ref)
+sub-hulls and merges them on demand. The lower hull spans from the leftmost to the rightmost
+point along the bottom boundary. Supports the same keyword arguments and incremental operations
+as [`MutableLowerConvexHull`](@ref), but does not accept [`mergehulls!`](@ref)/[`mergehulls`](@ref).
+
+See also: [`ChanConvexHull`](@ref), [`ChanUpperConvexHull`](@ref), [`addpoint!`](@ref), [`mergepoints!`](@ref), [`removepoint!`](@ref)
+"""
 ChanLowerConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = ChanLowerConvexHull{T,F}(; orientation, collinear, sortedby)
 
 mutable struct ChanUpperConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
@@ -92,6 +122,16 @@ function ChanUpperConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear:
     hull = TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}()
     return ChanUpperConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby)
 end
+"""
+    h = ChanUpperConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
+
+An upper convex hull that distributes its points across multiple [`MutableUpperConvexHull`](@ref)
+sub-hulls and merges them on demand. The upper hull spans from the leftmost to the rightmost
+point along the top boundary. Supports the same keyword arguments and incremental operations
+as [`MutableUpperConvexHull`](@ref), but does not accept [`mergehulls!`](@ref)/[`mergehulls`](@ref).
+
+See also: [`ChanConvexHull`](@ref), [`ChanLowerConvexHull`](@ref), [`addpoint!`](@ref), [`mergepoints!`](@ref), [`removepoint!`](@ref)
+"""
 ChanUpperConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = ChanUpperConvexHull{T,F}(; orientation, collinear, sortedby)
 
 function Base.empty!(h::AbstractChanConvexHull)

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -94,10 +94,10 @@ function ChanUpperConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::B
 end
 ChanUpperConvexHull{T}(orientation::HullOrientation=CCW,collinear::Bool=false,sortedby::F=identity) where {T,F} = ChanUpperConvexHull{T,F}(orientation,collinear,sortedby)
 
-function Base.empty!(h::AbstractChanConvexHull) 
+function Base.empty!(h::AbstractChanConvexHull)
     empty!(h.hull)
-    subhulls = [subhulls[1]]
-    empty!(subhulls[1])
+    h.subhulls = [h.subhulls[1]]
+    empty!(h.subhulls[1])
     emptycache!(h.cache)
     return h
 end

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -41,11 +41,11 @@ end
 emptycache!(::Nothing) = nothing
 
 mutable struct ChanConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
-    hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
+    const hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
     subhulls::Vector{MutableConvexHull{T,F}}
-    orientation::HullOrientation
-    collinear::Bool
-    sortedby::F
+    const orientation::HullOrientation
+    const collinear::Bool
+    const sortedby::F
     cache::Union{Nothing, ChanHullCache{T}}
     function ChanConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby, cache=nothing) where {T,F}
         return new(hull, subhulls, orientation, collinear, sortedby, cache)
@@ -59,11 +59,11 @@ end
 ChanConvexHull{T}(orientation::HullOrientation=CCW,collinear::Bool=false,sortedby::F=identity) where {T,F} = ChanConvexHull{T,F}(orientation,collinear,sortedby)
 
 mutable struct ChanLowerConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
-    hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
+    const hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
     subhulls::Vector{MutableLowerConvexHull{T,F}}
-    orientation::HullOrientation
-    collinear::Bool
-    sortedby::F
+    const orientation::HullOrientation
+    const collinear::Bool
+    const sortedby::F
     cache::Union{Nothing, ChanHullCache{T}}
     function ChanLowerConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby, cache=nothing) where {T,F}
         return new(hull, subhulls, orientation, collinear, sortedby, cache)
@@ -77,11 +77,11 @@ end
 ChanLowerConvexHull{T}(orientation::HullOrientation=CCW,collinear::Bool=false,sortedby::F=identity) where {T,F} = ChanLowerConvexHull{T,F}(orientation,collinear,sortedby)
 
 mutable struct ChanUpperConvexHull{T, F<:Function} <: AbstractChanConvexHull{T}
-    hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
+    const hull::TargetedLinkedList{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},PointNode{T,PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F},HullNode{T,HullList{T,F},F}}}
     subhulls::Vector{MutableUpperConvexHull{T,F}}
-    orientation::HullOrientation
-    collinear::Bool
-    sortedby::F
+    const orientation::HullOrientation
+    const collinear::Bool
+    const sortedby::F
     cache::Union{Nothing, ChanHullCache{T}}
     function ChanUpperConvexHull{T,F}(hull, subhulls, orientation, collinear, sortedby, cache=nothing) where {T,F}
         new(hull, subhulls, orientation, collinear, sortedby, cache)

--- a/src/chanhull.jl
+++ b/src/chanhull.jl
@@ -164,6 +164,14 @@ function removepoint!(h::AbstractChanConvexHull{T}, node::PointNode{T}) where T
     return h, updatedhull
 end
 
+function removepoint!(h::AbstractChanConvexHull{T}, value::T) where T
+    for shull in h.subhulls
+        node = findpointnode(shull.points, value)
+        node === nothing || return removepoint!(h, node)
+    end
+    throw(ArgumentError("No point equal to $value is contained in the convex hull"))
+end
+
 
 function copyfromcache(h::H) where {T,H<:AbstractChanConvexHull{T}}
     @assert !isnothing(h.cache)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -1,11 +1,11 @@
 abstract type AbstractConvexHull{T} end
 
 mutable struct MutableConvexHull{T, F<:Function} <: AbstractConvexHull{T}
-    hull::HullList{T,F}
-    points::PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}
-    orientation::HullOrientation
-    collinear::Bool
-    sortedby::F
+    const hull::HullList{T,F}
+    const points::PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}
+    const orientation::HullOrientation
+    const collinear::Bool
+    const sortedby::F
 end
 function MutableConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     points = PointList{T}(;sortedby=sortedby)
@@ -30,11 +30,11 @@ See also: [monotonechain](@ref), [jarvismarch](@ref), [addpoint!](@ref), [mergep
 MutableConvexHull{T}(orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableConvexHull{T,F}(orientation,collinear,sortedby)
 
 mutable struct MutableLowerConvexHull{T, F<:Function} <: AbstractConvexHull{T}
-    hull::HullList{T,F}
-    points::PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}
-    orientation::HullOrientation
-    collinear::Bool
-    sortedby::F
+    const hull::HullList{T,F}
+    const points::PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}
+    const orientation::HullOrientation
+    const collinear::Bool
+    const sortedby::F
 end
 function MutableLowerConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     points = PointList{T}(;sortedby=sortedby)
@@ -59,11 +59,11 @@ See also: [lower_monotonechain](@ref), [lower_jarvismarch](@ref), [addpoint!](@r
 MutableLowerConvexHull{T}(orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableLowerConvexHull{T,F}(orientation,collinear,sortedby)
 
 mutable struct MutableUpperConvexHull{T, F<:Function} <: AbstractConvexHull{T}
-    hull::HullList{T,F}
-    points::PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}
-    orientation::HullOrientation
-    collinear::Bool
-    sortedby::F
+    const hull::HullList{T,F}
+    const points::PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}
+    const orientation::HullOrientation
+    const collinear::Bool
+    const sortedby::F
 end
 function MutableUpperConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     points = PointList{T}(;sortedby=sortedby)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -93,8 +93,28 @@ Base.eltype(h::AbstractConvexHull) = eltype(h.hull)
 
 Base.:(==)(h1::AbstractConvexHull, h2::AbstractConvexHull) = h1.hull == h2.hull
 
+# Hash the hull-vertex sequence that `==` compares, so equal hulls hash equally
+# and behave correctly as `Dict` keys or `Set` elements.
+function Base.hash(h::AbstractConvexHull, x::UInt)
+    x = hash(:AbstractConvexHull, x)
+    for data in h
+        x = hash(data, x)
+    end
+    return x
+end
+
 Base.empty!(h::AbstractConvexHull) = empty!(h.hull)
 Base.empty(h::H) where H <: AbstractConvexHull = H(h.orientation, h.collinear, h.sortedby)
+
+# Deep copy by replaying the contained points: the result shares no linked-list
+# nodes with `h`, so mutating one hull never affects the other.
+function Base.copy(h::H) where {H<:AbstractConvexHull}
+    hcopy = H(h.orientation, h.collinear, h.sortedby)
+    for node in PointNodeIterator(h)
+        addpoint!(hcopy, node.data)
+    end
+    return hcopy
+end
 
 # Iterating a convex hull returns the data contained in the nodes of its hull list
 Base.iterate(h::AbstractConvexHull) = iterate(h, h.hull.head.next)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -220,6 +220,8 @@ end
 Add `points` to the list of points contained by the provided convex hull `hull`. If any of the `points` lie outside the convex hull,
 the list of hull points will be updated accordingly.
 
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
+
 This function finds the convex hull of the `points` to be added before merging them with the `hull`. See 
 [Chan's algorithm](https://en.wikipedia.org/wiki/Chan%27s_algorithm) for a similar idea.
 
@@ -240,7 +242,7 @@ function mergepoints!(h::MutableUpperConvexHull{T}, points::AbstractVector{T}) w
     mergehulls!(h,h2)
     return h
 end
-mergepoints!(h::AbstractConvexHull, points::Matrix) = mergepoints!(h, [(points[i,:]...,) for i=1:size(points,1)])
+mergepoints!(h::AbstractConvexHull, points::AbstractMatrix) = mergepoints!(h, rowpoints(points))
 
 """
     removepoint!(hull, node)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -318,6 +318,35 @@ function removepoint!(h::MutableConvexHull{T}, node::PointNode{T}) where T
     end
 end
 
+# Locate the point node whose data equals `value`, or `nothing` if absent.
+# `search` lands on the last node whose sort key is ≤ that of `value`; scanning
+# back across the equal-key run and comparing full coordinates handles a
+# `sortedby` that maps distinct points to the same key.
+function findpointnode(points::PointList{T}, value::T) where T
+    node = search(points, value)
+    svalue = points.sortedby(value)
+    while !athead(node) && points.sortedby(node.data) == svalue
+        coordsareequal(node.data, value) && return node
+        node = node.prev
+    end
+    return nothing
+end
+
+"""
+    removepoint!(hull, value)
+
+Locate the point equal to `value` contained in `hull` and remove it, delegating
+to [`removepoint!`](@ref)`(hull, node)`. Throws an `ArgumentError` if no point
+equal to `value` is contained in `hull`.
+
+See also: [addpoint!](@ref), [mergepoints!](@ref)
+"""
+function removepoint!(h::AbstractConvexHull{T}, value::T) where T
+    node = findpointnode(h.points, value)
+    node === nothing && throw(ArgumentError("No point equal to $value is contained in the convex hull"))
+    return removepoint!(h, node)
+end
+
 # returns true if all points in a convex hull are collinear
 function allcollinear(h::AbstractConvexHull)
     length(h) < 3 && return true

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -1,3 +1,12 @@
+"""
+    AbstractConvexHull{T}
+
+Abstract supertype for all convex hull types over 2-D points of type `T`.
+
+Concrete subtypes: [`MutableConvexHull`](@ref), [`MutableLowerConvexHull`](@ref),
+[`MutableUpperConvexHull`](@ref), [`ChanConvexHull`](@ref), [`ChanLowerConvexHull`](@ref),
+[`ChanUpperConvexHull`](@ref).
+"""
 abstract type AbstractConvexHull{T} end
 
 mutable struct MutableConvexHull{T, F<:Function} <: AbstractConvexHull{T}

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -150,6 +150,8 @@ Base.iterate(iter::HullNodeIterator) = iterate(iter, iter.start)
 Base.iterate(iter::HullNodeIterator{S}, node::S) where {S<:HullNode} = iter.rev ? (athead(node) ? nothing : (node, node.prev)) :
                                                                                   (attail(node) ? nothing : (node, node.next))
 Base.IteratorSize(::HullNodeIterator) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:HullNodeIterator}) = Base.HasEltype()
+Base.eltype(::Type{<:HullNodeIterator{S}}) where {S<:HullNode} = S
 
 
 struct PointNodeIterator{S<:PointNode}
@@ -183,6 +185,8 @@ Base.iterate(iter::PointNodeIterator) = iterate(iter, iter.start)
 Base.iterate(iter::PointNodeIterator{S}, node::S) where S = iter.rev ? (athead(node) ? nothing : (node, node.prev)) :
                                                                        (attail(node) ? nothing : (node, node.next))
 Base.IteratorSize(::PointNodeIterator) = Base.SizeUnknown()
+Base.IteratorEltype(::Type{<:PointNodeIterator}) = Base.HasEltype()
+Base.eltype(::Type{<:PointNodeIterator{S}}) where {S<:PointNode} = S
 
 """
     addpoint!(hull, point)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -7,7 +7,7 @@ mutable struct MutableConvexHull{T, F<:Function} <: AbstractConvexHull{T}
     const collinear::Bool
     const sortedby::F
 end
-function MutableConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
+function MutableConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     points = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,F}()
     addtarget!(hull,points)
@@ -15,7 +15,7 @@ function MutableConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Boo
 end
 
 """
-    h = MutableConvexHull{T}([, orientation, collinear, sortedby])
+    h = MutableConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
 
 Initialize an empty `MutableConvexHull` with the provided attributes.
 
@@ -27,7 +27,7 @@ Initialize an empty `MutableConvexHull` with the provided attributes.
 
 See also: [monotonechain](@ref), [jarvismarch](@ref), [addpoint!](@ref), [mergepoints!](@ref), [removepoint!](@ref)
 """
-MutableConvexHull{T}(orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableConvexHull{T,F}(orientation,collinear,sortedby)
+MutableConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableConvexHull{T,F}(; orientation, collinear, sortedby)
 
 mutable struct MutableLowerConvexHull{T, F<:Function} <: AbstractConvexHull{T}
     const hull::HullList{T,F}
@@ -36,7 +36,7 @@ mutable struct MutableLowerConvexHull{T, F<:Function} <: AbstractConvexHull{T}
     const collinear::Bool
     const sortedby::F
 end
-function MutableLowerConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
+function MutableLowerConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     points = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,F}()
     addtarget!(hull,points)
@@ -44,7 +44,7 @@ function MutableLowerConvexHull{T,F}(orientation::HullOrientation=CCW, collinear
 end
 
 """
-    h = MutableLowerConvexHull{T}([, orientation, collinear, sortedby])
+    h = MutableLowerConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
 
 Initialize an empty `MutableLowerConvexHull` with the provided attributes.
 
@@ -56,7 +56,7 @@ Initialize an empty `MutableLowerConvexHull` with the provided attributes.
 
 See also: [lower_monotonechain](@ref), [lower_jarvismarch](@ref), [addpoint!](@ref), [mergepoints!](@ref), [removepoint!](@ref)
 """
-MutableLowerConvexHull{T}(orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableLowerConvexHull{T,F}(orientation,collinear,sortedby)
+MutableLowerConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableLowerConvexHull{T,F}(; orientation, collinear, sortedby)
 
 mutable struct MutableUpperConvexHull{T, F<:Function} <: AbstractConvexHull{T}
     const hull::HullList{T,F}
@@ -65,7 +65,7 @@ mutable struct MutableUpperConvexHull{T, F<:Function} <: AbstractConvexHull{T}
     const collinear::Bool
     const sortedby::F
 end
-function MutableUpperConvexHull{T,F}(orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
+function MutableUpperConvexHull{T,F}(; orientation::HullOrientation=CCW, collinear::Bool=false, sortedby::F=identity) where {T,F}
     points = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,F}()
     addtarget!(hull,points)
@@ -73,7 +73,7 @@ function MutableUpperConvexHull{T,F}(orientation::HullOrientation=CCW, collinear
 end
 
 """
-    h = MutableUpperConvexHull{T}([, orientation, collinear, sortedby])
+    h = MutableUpperConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
 
 Initialize an empty `MutableUpperConvexHull` with the provided attributes.
 
@@ -85,7 +85,7 @@ Initialize an empty `MutableUpperConvexHull` with the provided attributes.
 
 See also: [upper_monotonechain](@ref), [upper_jarvismarch](@ref), [addpoint!](@ref), [mergepoints!](@ref), [removepoint!](@ref)
 """
-MutableUpperConvexHull{T}(orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableUpperConvexHull{T,F}(orientation,collinear, sortedby)
+MutableUpperConvexHull{T}(; orientation=CCW, collinear=false, sortedby::F=identity) where {T,F} = MutableUpperConvexHull{T,F}(; orientation, collinear, sortedby)
 
 Base.isempty(h::AbstractConvexHull) = isempty(h.hull)
 Base.length(h::AbstractConvexHull) = length(h.hull)
@@ -104,12 +104,12 @@ function Base.hash(h::AbstractConvexHull, x::UInt)
 end
 
 Base.empty!(h::AbstractConvexHull) = empty!(h.hull)
-Base.empty(h::H) where H <: AbstractConvexHull = H(h.orientation, h.collinear, h.sortedby)
+Base.empty(h::H) where H <: AbstractConvexHull = H(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
 
 # Deep copy by replaying the contained points: the result shares no linked-list
 # nodes with `h`, so mutating one hull never affects the other.
 function Base.copy(h::H) where {H<:AbstractConvexHull}
-    hcopy = H(h.orientation, h.collinear, h.sortedby)
+    hcopy = H(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
     for node in PointNodeIterator(h)
         addpoint!(hcopy, node.data)
     end

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -351,17 +351,6 @@ function removepoint!(h::AbstractConvexHull{T}, value::T) where T
     return removepoint!(h, node)
 end
 
-# returns true if all points in a convex hull are collinear
-function allcollinear(h::AbstractConvexHull)
-    length(h) < 3 && return true
-    headnode = head(h.hull)
-    o = coords(headnode.data)
-    a = coords(headnode.next.data)
-    b = coords(tail(h.hull).data)
-    return iscollinear(sub2d(a,o),o,b)
-end
-
-
 function Base.show(io::IO, h::AbstractConvexHull)
     print(io, typeof(h), '(')
     join(io, h, ", ")

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -125,7 +125,7 @@ struct HullNodeIterator{S<:HullNode}
     rev::Bool
 end
 """
-    HullNodeIterator(start [, rev])
+    HullNodeIterator(start[; rev=false])
 
 Returns an iterator over the nodes in the linked list representing the convex hull, starting at the specified node `start`.
 
@@ -137,7 +137,7 @@ function HullNodeIterator(start::S; rev::Bool = false) where {S<:HullNode}
 end
 
 """
-    HullNodeIterator(hull [, rev])
+    HullNodeIterator(hull[; rev=false])
 
 Returns an iterator over the nodes in the linked list representing the convex hull.
 
@@ -159,7 +159,7 @@ struct PointNodeIterator{S<:PointNode}
     rev::Bool
 end
 """
-    PointNodeIterator(start [, rev])
+    PointNodeIterator(start[; rev=false])
 
 Returns an iterator over the nodes in the linked list representing the points contained by the convex hull,
 starting at the specified node `start`.
@@ -172,7 +172,7 @@ function PointNodeIterator(start::S; rev::Bool = false) where S
 end
 
 """
-    PointNodeIterator(hull [, rev])
+    PointNodeIterator(hull[; rev=false])
 
 Returns an iterator over the nodes in the linked list representing the points contained by the convex hull.
 

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -17,7 +17,11 @@ end
 """
     h = MutableConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
 
-Initialize an empty `MutableConvexHull` with the provided attributes.
+A mutable convex hull over 2-D points of type `T` (e.g., `Tuple{Float64,Float64}`),
+supporting incremental addition and removal of points. Iterating `h` yields the
+hull-vertex sequence in the specified orientation.
+
+Initialize an empty hull with the provided attributes.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -46,7 +50,11 @@ end
 """
     h = MutableLowerConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
 
-Initialize an empty `MutableLowerConvexHull` with the provided attributes.
+A mutable lower convex hull over 2-D points of type `T` (e.g., `Tuple{Float64,Float64}`):
+the chain of hull vertices from the leftmost to the rightmost point along the bottom boundary.
+Supports the same incremental operations as [`MutableConvexHull`](@ref).
+
+Initialize an empty hull with the provided attributes.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -75,7 +83,11 @@ end
 """
     h = MutableUpperConvexHull{T}(; orientation=CCW, collinear=false, sortedby=identity)
 
-Initialize an empty `MutableUpperConvexHull` with the provided attributes.
+A mutable upper convex hull over 2-D points of type `T` (e.g., `Tuple{Float64,Float64}`):
+the chain of hull vertices from the leftmost to the rightmost point along the top boundary.
+Supports the same incremental operations as [`MutableConvexHull`](@ref).
+
+Initialize an empty hull with the provided attributes.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -127,10 +139,11 @@ end
 """
     HullNodeIterator(start[; rev=false])
 
-Returns an iterator over the nodes in the linked list representing the convex hull, starting at the specified node `start`.
+Return an iterator over the [`HullNode`](@ref) elements in the convex hull's linked
+list, starting at `start`.
 
-If `rev` is `true`, the iterator will advance toward the head of the list.
-Otherwise, it will advance toward the tail of the list.
+If `rev` is `true`, the iterator advances toward the head of the list.
+Otherwise, it advances toward the tail.
 """
 function HullNodeIterator(start::S; rev::Bool = false) where {S<:HullNode}
     return HullNodeIterator{S}(start, rev)
@@ -139,10 +152,10 @@ end
 """
     HullNodeIterator(hull[; rev=false])
 
-Returns an iterator over the nodes in the linked list representing the convex hull.
+Return an iterator over the [`HullNode`](@ref) elements in the convex hull's linked list.
 
-If `rev` is `true`, the iterator will start at the tail of the list and advance toward the head.
-Otherwise, it will start at the head of the list and advance toward the tail.
+If `rev` is `true`, iteration starts at the tail and advances toward the head.
+Otherwise, it starts at the head and advances toward the tail.
 """
 HullNodeIterator(h::AbstractConvexHull; rev::Bool = false) = HullNodeIterator{nodetype(h.hull)}(rev ? h.hull.tail.prev : h.hull.head.next, rev)
 
@@ -161,11 +174,11 @@ end
 """
     PointNodeIterator(start[; rev=false])
 
-Returns an iterator over the nodes in the linked list representing the points contained by the convex hull,
-starting at the specified node `start`.
+Return an iterator over the [`PointNode`](@ref) elements in the hull's point list,
+starting at `start`.
 
-If `rev` is `true`, the iterator will advance toward the head of the list.
-Otherwise, it will advance toward the tail of the list.
+If `rev` is `true`, the iterator advances toward the head of the list.
+Otherwise, it advances toward the tail.
 """
 function PointNodeIterator(start::S; rev::Bool = false) where S
     return PointNodeIterator{S}(start, rev)
@@ -174,10 +187,10 @@ end
 """
     PointNodeIterator(hull[; rev=false])
 
-Returns an iterator over the nodes in the linked list representing the points contained by the convex hull.
+Return an iterator over the [`PointNode`](@ref) elements in the hull's point list.
 
-If `rev` is `true`, the iterator will start at the tail of the list and advance toward the head.
-Otherwise, it will start at the head of the list and advance toward the tail.
+If `rev` is `true`, iteration starts at the tail and advances toward the head.
+Otherwise, it starts at the head and advances toward the tail.
 """
 PointNodeIterator(h::AbstractConvexHull; rev::Bool = false) = PointNodeIterator{nodetype(h.points)}(rev ? h.points.tail.prev : h.points.head.next, rev)
 
@@ -194,7 +207,25 @@ Base.eltype(::Type{<:PointNodeIterator{S}}) where {S<:PointNode} = S
 Add `point` to the list of points contained by the provided convex hull `hull`. If `point` lies outside the convex hull,
 the list of hull points will be updated accordingly.
 
-Returns a tuple containing the hull and a boolean, which is true if the added point expands the convex hull and is false otherwise.
+Return `(hull, expanded)` where `expanded` is `true` if the added point expands the hull
+and `false` if it lies inside or on the boundary.
+
+# Examples
+```jldoctest
+julia> h = MutableConvexHull{Tuple{Float64,Float64}}();
+
+julia> h, _ = addpoint!(h, (0.0, 0.0)); h, _ = addpoint!(h, (1.0, 0.0));
+
+julia> h, expanded = addpoint!(h, (0.0, 1.0));
+
+julia> expanded
+true
+
+julia> h, expanded = addpoint!(h, (0.25, 0.25));
+
+julia> expanded
+false
+```
 
 See also: [mergepoints!](@ref), [removepoint!](@ref)
 """
@@ -222,8 +253,10 @@ the list of hull points will be updated accordingly.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
-This function finds the convex hull of the `points` to be added before merging them with the `hull`. See 
+This function finds the convex hull of the `points` to be added before merging them with the `hull`. See
 [Chan's algorithm](https://en.wikipedia.org/wiki/Chan%27s_algorithm) for a similar idea.
+
+Return `hull`.
 
 See also: [addpoint!](@ref), [removepoint!](@ref)
 """
@@ -247,10 +280,12 @@ mergepoints!(h::AbstractConvexHull, points::AbstractMatrix) = mergepoints!(h, ro
 """
     removepoint!(hull, node)
 
-Removes `node` from `hull`. If the `node` corresponds to a point on the convex hull, the list of hull points will be updated accordingly.
+Remove `node` from `hull`. `node` may be a [`HullNode`](@ref) (a vertex on the hull
+boundary) or a [`PointNode`](@ref) (any tracked point, inside or on the boundary). If
+removing `node` alters the hull boundary, it is recomputed.
 
-Returns a tuple containing the hull and a boolean, which is true if a point on the convex hull was removed and is false if an interior
-or duplicate point was removed.
+Return `(hull, removed)` where `removed` is `true` if a hull-boundary vertex was
+removed and `false` if an interior or duplicate point was removed.
 
 See also: [addpoint!](@ref), [mergepoints!](@ref)
 """
@@ -341,9 +376,30 @@ end
 """
     removepoint!(hull, value)
 
-Locate the point equal to `value` contained in `hull` and remove it, delegating
-to [`removepoint!`](@ref)`(hull, node)`. Throws an `ArgumentError` if no point
+Locate the point equal to `value` in `hull` and remove it, delegating to
+[`removepoint!`](@ref)`(hull, node)`. Throws an `ArgumentError` if no point
 equal to `value` is contained in `hull`.
+
+Return `(hull, removed)` where `removed` is `true` if a hull-boundary vertex
+was removed and `false` if an interior or duplicate point was removed.
+
+# Examples
+```jldoctest
+julia> h = monotonechain([(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (0.25, 0.25)]);
+
+julia> h, removed = removepoint!(h, (0.25, 0.25));
+
+julia> removed  # interior point; hull boundary unchanged
+false
+
+julia> h, removed = removepoint!(h, (1.0, 0.0));
+
+julia> removed  # hull vertex; boundary recomputed
+true
+
+julia> h
+MutableConvexHull{Tuple{Float64, Float64}, typeof(identity)}((0.0, 0.0), (0.0, 1.0))
+```
 
 See also: [addpoint!](@ref), [mergepoints!](@ref)
 """

--- a/src/inside.jl
+++ b/src/inside.jl
@@ -13,10 +13,11 @@ Return `true` if `data` lies inside `hull` and `false` otherwise.
 `data` must be a 2-D indexable point, supporting `data[1]` and `data[2]`; a
 scalar or other non-indexable value raises a `BoundsError`.
 
-Boundary handling is governed by `hull.collinear`. With the default
-`collinear=false`, points on an edge or vertex of `hull` count as inside.
+Boundary handling is governed by `hull.collinear`. Points that exactly coincide
+with a hull vertex always count as inside. For non-vertex boundary points, the
+default `collinear=false` treats hull edges as inside; `collinear=true` treats
+them as outside (so they will be added to the hull on merge).
 
-`data ∈ hull` (equivalently `data in hull`) is shorthand for `insidehull(data, hull)`.
 """
 function insidehull(pointdata::T, h::FullHull{T}) where T
     length(h) == 0 && return false
@@ -49,10 +50,10 @@ function insidehull(pointdata::T, h::FullHull{T}) where T
                     nextnode.data != nextnextnode.data && return false
                 # if the point is even with the previous node...
                 elseif pointdata[1] == prevnode.data[1]
-                    abovelower = h.collinear ? pointdata[2] > prevnode.data[2] : pointdata[2] >= prevnode.data[2]
+                    abovelower = coordsareequal(pointdata, prevnode.data) || (h.collinear ? pointdata[2] > prevnode.data[2] : pointdata[2] >= prevnode.data[2])
                 # if the point is even with the next node...
                 elseif pointdata[1] == nextnode.data[1] !== nextnextnode.data[1]
-                    abovelower = h.collinear ? pointdata[2] > nextnode.data[2] : pointdata[2] >= nextnode.data[2]
+                    abovelower = coordsareequal(pointdata, nextnode.data) || (h.collinear ? pointdata[2] > nextnode.data[2] : pointdata[2] >= nextnode.data[2])
                 # if the point is in between the previous and next nodes...
                 elseif ccw ? (prevnode.data[1] < pointdata[1] < nextnode.data[1]) : (prevnode.data[1] > pointdata[1] > nextnode.data[1])
                     yhull = linterp(pointdata[1], prevnode.data, nextnode.data)
@@ -75,10 +76,10 @@ function insidehull(pointdata::T, h::FullHull{T}) where T
                 belowupper && return true # we can stop if we know the hull is within both the upper and lower hulls
             # if the point is even with the previous node...
             elseif pointdata[1] == prevnode.data[1]
-                belowupper = h.collinear ? pointdata[2] < prevnode.data[2] : pointdata[2] <= prevnode.data[2]
+                belowupper = coordsareequal(pointdata, prevnode.data) || (h.collinear ? pointdata[2] < prevnode.data[2] : pointdata[2] <= prevnode.data[2])
             # if the point is even with the next node...
             elseif pointdata[1] == nextnode.data[1]
-                belowupper = h.collinear ? pointdata[2] < nextnode.data[2] : pointdata[2] <= nextnode.data[2]
+                belowupper = coordsareequal(pointdata, nextnode.data) || (h.collinear ? pointdata[2] < nextnode.data[2] : pointdata[2] <= nextnode.data[2])
             # if the point is in between the previous and next nodes...
             elseif ccw ? (prevnode.data[1] >= pointdata[1] >= nextnode.data[1]) : (prevnode.data[1] <= pointdata[1] <= nextnode.data[1])
                 yhull = linterp(pointdata[1], prevnode.data, nextnode.data)
@@ -136,6 +137,7 @@ function insidehull(pointdata::T, h::LowerHull{T}) where T
     for nextnode in h.hull.head.next.next
         prevnode = nextnode.prev
         if ccw ? (prevnode.data[1] <= pointdata[1] <= nextnode.data[1]) : (prevnode.data[1] >= pointdata[1] >= nextnode.data[1])
+            (coordsareequal(pointdata, prevnode.data) || coordsareequal(pointdata, nextnode.data)) && return true
             yhull = linterp(pointdata[1], prevnode.data, nextnode.data)
             if h.collinear ? pointdata[2] > yhull : pointdata[2] >= yhull
                 return true
@@ -189,6 +191,7 @@ function insidehull(pointdata::T, h::UpperHull{T}) where T
     for nextnode in h.hull.head.next.next
         prevnode = nextnode.prev
         if ccw ? (prevnode.data[1] >= pointdata[1] >= nextnode.data[1]) : (prevnode.data[1] <= pointdata[1] <= nextnode.data[1])
+            (coordsareequal(pointdata, prevnode.data) || coordsareequal(pointdata, nextnode.data)) && return true
             yhull = linterp(pointdata[1], prevnode.data, nextnode.data)
             if h.collinear ? pointdata[2] < yhull : pointdata[2] <= yhull
                 return true
@@ -199,5 +202,3 @@ function insidehull(pointdata::T, h::UpperHull{T}) where T
 end
 
 insidehull(pointnode::AbstractNode, h::AbstractConvexHull) = insidehull(pointnode.data, h)
-
-Base.in(item, h::AbstractConvexHull) = insidehull(item, h)

--- a/src/inside.jl
+++ b/src/inside.jl
@@ -190,4 +190,4 @@ function insidehull(pointdata::T, h::UpperHull{T}) where T
     return false
 end
 
-insidehull(pointnode::PairedListNode, h::AbstractConvexHull) = insidehull(pointnode.data, h)
+insidehull(pointnode::AbstractNode, h::AbstractConvexHull) = insidehull(pointnode.data, h)

--- a/src/inside.jl
+++ b/src/inside.jl
@@ -1,9 +1,16 @@
+# `insidehull` reads only the ordered hull-vertex list and the orientation,
+# collinear, and sortedby attributes, all shared by a regular and a Chan hull of
+# the same kind, so each kind's test serves both representations.
+const FullHull{T}  = Union{MutableConvexHull{T}, ChanConvexHull{T}}
+const LowerHull{T} = Union{MutableLowerConvexHull{T}, ChanLowerConvexHull{T}}
+const UpperHull{T} = Union{MutableUpperConvexHull{T}, ChanUpperConvexHull{T}}
+
 """
     insidehull(data, hull) -> Bool
 
 Return `true` if the data lies within the interior of `hull` and `false` otherwise.
 """
-function insidehull(pointdata::T, h::MutableConvexHull{T}) where T
+function insidehull(pointdata::T, h::FullHull{T}) where T
     length(h) == 0 && return false
     length(h) == 1 && return coordsareequal(pointdata, h.hull.head.next.data)
 
@@ -77,7 +84,7 @@ function insidehull(pointdata::T, h::MutableConvexHull{T}) where T
     return abovelower && belowupper
 end
 
-function insidehull(pointdata::T, h::MutableLowerConvexHull{T}) where T
+function insidehull(pointdata::T, h::LowerHull{T}) where T
     length(h) == 0 && return false
     length(h) == 1 && return coordsareequal(pointdata, h.hull.head.next.data)
     ccw = h.orientation === CCW
@@ -130,7 +137,7 @@ function insidehull(pointdata::T, h::MutableLowerConvexHull{T}) where T
     return false
 end
 
-function insidehull(pointdata::T, h::MutableUpperConvexHull{T}) where T
+function insidehull(pointdata::T, h::UpperHull{T}) where T
     length(h) == 0 && return false
     length(h) == 1 && return coordsareequal(pointdata, h.hull.head.next.data)
     ccw = h.orientation == CCW

--- a/src/inside.jl
+++ b/src/inside.jl
@@ -8,7 +8,12 @@ const UpperHull{T} = Union{MutableUpperConvexHull{T}, ChanUpperConvexHull{T}}
 """
     insidehull(data, hull) -> Bool
 
-Return `true` if the data lies within the interior of `hull` and `false` otherwise.
+Return `true` if `data` lies inside `hull` and `false` otherwise.
+
+Boundary handling is governed by `hull.collinear`. With the default
+`collinear=false`, points on an edge or vertex of `hull` count as inside.
+
+`data ∈ hull` (equivalently `data in hull`) is shorthand for `insidehull(data, hull)`.
 """
 function insidehull(pointdata::T, h::FullHull{T}) where T
     length(h) == 0 && return false
@@ -191,3 +196,5 @@ function insidehull(pointdata::T, h::UpperHull{T}) where T
 end
 
 insidehull(pointnode::AbstractNode, h::AbstractConvexHull) = insidehull(pointnode.data, h)
+
+Base.in(item, h::AbstractConvexHull) = insidehull(item, h)

--- a/src/inside.jl
+++ b/src/inside.jl
@@ -10,6 +10,9 @@ const UpperHull{T} = Union{MutableUpperConvexHull{T}, ChanUpperConvexHull{T}}
 
 Return `true` if `data` lies inside `hull` and `false` otherwise.
 
+`data` must be a 2-D indexable point, supporting `data[1]` and `data[2]`; a
+scalar or other non-indexable value raises a `BoundsError`.
+
 Boundary handling is governed by `hull.collinear`. With the default
 `collinear=false`, points on an edge or vertex of `hull` count as inside.
 

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -24,7 +24,6 @@ Each node in the list should contain a two-dimensional point, and the nodes are 
 (e.g. by lowest "x" value and by lowest "y" in case of ties, though some other sorting methods may produce valid results).
 """
 function jarvismarch!(hull::Union{AbstractConvexHull{T},AbstractList{T}}, pointslist, collinear, orientation, initedge, stop::Union{PointNode{T},HullNode{T},Nothing}=nothing) where T
-    # pointslist = h.hull.target   
     length(hull) > 0 || throw(ArgumentError("jarvismarch! requires a hull containing at least one point"))
     if isnothing(stop)
         stop = head(hull)

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -176,7 +176,7 @@ function jarvismarch(points::AbstractVector{T}; orientation::HullOrientation=CCW
     pointslist = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,typeof(sortedby)}()
     addtarget!(hull, pointslist)
-    !isempty(points) && push!(pointslist, points...)
+    for p in points; push!(pointslist, p); end
     h = MutableConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     jarvismarch!(h)
     return h
@@ -200,7 +200,7 @@ function lower_jarvismarch(points::AbstractVector{T}; orientation::HullOrientati
     pointslist = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,typeof(sortedby)}()
     addtarget!(hull, pointslist)
-    !isempty(points) && push!(pointslist, points...)
+    for p in points; push!(pointslist, p); end
     h = MutableLowerConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     jarvismarch!(h)
     return h
@@ -224,7 +224,7 @@ function upper_jarvismarch(points::AbstractVector{T}; orientation::HullOrientati
     pointslist = PointList{T}(;sortedby=sortedby)
     hull = HullList{T,typeof(sortedby)}()
     addtarget!(hull, pointslist)
-    !isempty(points) && push!(pointslist, points...)
+    for p in points; push!(pointslist, p); end
     h = MutableUpperConvexHull{T, typeof(sortedby)}(hull, pointslist, orientation, collinear, sortedby)
     jarvismarch!(h)
     return h

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -165,6 +165,8 @@ end
 
 Return the convex hull generated from the provided `points`.
 
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
+
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
 `collinear` specifies whether collinear points are allowed along the surface of the convex hull, and defaults to `false`.
@@ -180,11 +182,14 @@ function jarvismarch(points::AbstractVector{T}; orientation::HullOrientation=CCW
     jarvismarch!(h)
     return h
 end
+jarvismarch(points::AbstractMatrix; kwargs...) = jarvismarch(rowpoints(points); kwargs...)
 
 """
     lh = lower_jarvismarch(points [; orientation, collinear, sortedby])
 
 Return the lower convex hull generated from the provided `points`.
+
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -201,11 +206,14 @@ function lower_jarvismarch(points::AbstractVector{T}; orientation::HullOrientati
     jarvismarch!(h)
     return h
 end
+lower_jarvismarch(points::AbstractMatrix; kwargs...) = lower_jarvismarch(rowpoints(points); kwargs...)
 
 """
     uh = upper_jarvismarch(points [; orientation, collinear, sortedby])
 
 Return the upper convex hull generated from the provided `points`.
+
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -222,3 +230,4 @@ function upper_jarvismarch(points::AbstractVector{T}; orientation::HullOrientati
     jarvismarch!(h)
     return h
 end
+upper_jarvismarch(points::AbstractMatrix; kwargs...) = upper_jarvismarch(rowpoints(points); kwargs...)

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -136,7 +136,7 @@ function jarvismarch!(h::MutableUpperConvexHull)
         push!(h.hull, first(h.hull.target))
         addtarget!(head(h.hull), head(h.hull.target))
     end
-    length(h.hull.target) <= 1 && return h.hull
+    length(h.hull.target) <= 1 && return h
 
     # select the appropriate starting and stopping nodes
     f = node -> h.sortedby(node.data)

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -25,7 +25,7 @@ Each node in the list should contain a two-dimensional point, and the nodes are 
 """
 function jarvismarch!(hull::Union{AbstractConvexHull{T},AbstractList{T}}, pointslist, collinear, orientation, initedge, stop::Union{PointNode{T},HullNode{T},Nothing}=nothing) where T
     # pointslist = h.hull.target   
-    @assert length(hull) > 0
+    length(hull) > 0 || throw(ArgumentError("jarvismarch! requires a hull containing at least one point"))
     if isnothing(stop)
         stop = head(hull)
     end

--- a/src/jarvismarch.jl
+++ b/src/jarvismarch.jl
@@ -162,7 +162,7 @@ end
 """
     h = jarvismarch(points [; orientation, collinear, sortedby])
 
-Return the convex hull generated from the provided `points`.
+Return a [`MutableConvexHull`](@ref) containing the convex hull of the provided `points`.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
@@ -186,7 +186,7 @@ jarvismarch(points::AbstractMatrix; kwargs...) = jarvismarch(rowpoints(points); 
 """
     lh = lower_jarvismarch(points [; orientation, collinear, sortedby])
 
-Return the lower convex hull generated from the provided `points`.
+Return a [`MutableLowerConvexHull`](@ref) containing the lower convex hull of the provided `points`.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
@@ -210,7 +210,7 @@ lower_jarvismarch(points::AbstractMatrix; kwargs...) = lower_jarvismarch(rowpoin
 """
     uh = upper_jarvismarch(points [; orientation, collinear, sortedby])
 
-Return the upper convex hull generated from the provided `points`.
+Return a [`MutableUpperConvexHull`](@ref) containing the upper convex hull of the provided `points`.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -36,9 +36,10 @@
 """
     mergehulls!(hull, otherhulls...)
 
-Merge the points contained in `otherhulls` into `hull`. All arguments must be
-the same concrete hull type (`MutableConvexHull`, `MutableLowerConvexHull`, or
-`MutableUpperConvexHull`). See [Chan's algorithm](https://en.wikipedia.org/wiki/Chan%27s_algorithm)
+Merge the points contained in `otherhulls` into `hull` and return `hull`. All
+arguments must be the same concrete hull type (`MutableConvexHull`,
+`MutableLowerConvexHull`, or `MutableUpperConvexHull`); [`AbstractChanConvexHull`](@ref)
+subtypes are not accepted. See [Chan's algorithm](https://en.wikipedia.org/wiki/Chan%27s_algorithm)
 for a similar approach.
 """
 function mergehulls!(h::H, others::H...) where H<:Union{MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull}
@@ -83,8 +84,9 @@ end
 """
     mergehulls(hull, otherhulls...)
 
-Return a new convex hull containing the points of `hull` and `otherhulls`,
-without mutating any argument. See [`mergehulls!`](@ref) for the in-place form.
+Return a new hull of the same type as `hull` containing the points of `hull` and
+`otherhulls`, without mutating any argument. See [`mergehulls!`](@ref) for the
+in-place form.
 """
 mergehulls(h::H, others::H...) where H <: Union{MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull} = mergehulls!(copy(h), others...)
 

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -1,32 +1,36 @@
-function jarvissortedsearch(query::AbstractNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
-    pointslist.len == 0 && throw(ArgumentError("The list of points must not be empty."))
-    pointslist.len == 1 && return head(pointslist)
-    coordsareequal(head(pointslist).data, tail(pointslist).data) && throw(ArgumentError("All points in the list are duplicates."))
-    # find nodes around the start of the list that are distinct from the query data
-    prevnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(pointslist; rev=true))
-    prevnode === nothing && return head(pointslist)
-    currentnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(pointslist; rev=false))
-    currentnode === prevnode && return currentnode
-    nextnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(currentnode.next; rev=false))
-    if nextnode === nothing 
-        return betterturn(prevedge, query.data, prevnode.data, currentnode.data) ? currentnode : prevnode
-    end
-    # initialize comparision with previous node
-    prev_worse = !betterturn(prevedge, query.data, currentnode.data, prevnode.data)
-
-    while nextnode !== nothing
-        # since points are sorted, the next point should present a "better turn" than the preceding or following points
-        next_worse = !betterturn(prevedge, query.data, currentnode.data, nextnode.data)
-        if prev_worse && next_worse
-            return currentnode
-        end
-        prev_worse = !next_worse
-        prevnode = currentnode
-        currentnode = nextnode
-        nextnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(currentnode.next; rev=false))
-    end
-    return currentnode
-end
+# jarvissortedsearch is a potential optimization of jarvissearch that exploits the
+# sorted order of the hull list. It is not currently used (jarvissearch is used instead)
+# but is retained as a reference for future optimization work.
+#
+# function jarvissortedsearch(query::AbstractNode, prevedge, pointslist::AbstractLinkedList, betterturn::Function)
+#     pointslist.len == 0 && throw(ArgumentError("The list of points must not be empty."))
+#     pointslist.len == 1 && return head(pointslist)
+#     coordsareequal(head(pointslist).data, tail(pointslist).data) && throw(ArgumentError("All points in the list are duplicates."))
+#     # find nodes around the start of the list that are distinct from the query data
+#     prevnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(pointslist; rev=true))
+#     prevnode === nothing && return head(pointslist)
+#     currentnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(pointslist; rev=false))
+#     currentnode === prevnode && return currentnode
+#     nextnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(currentnode.next; rev=false))
+#     if nextnode === nothing
+#         return betterturn(prevedge, query.data, prevnode.data, currentnode.data) ? currentnode : prevnode
+#     end
+#     # initialize comparision with previous node
+#     prev_worse = !betterturn(prevedge, query.data, currentnode.data, prevnode.data)
+#
+#     while nextnode !== nothing
+#         # since points are sorted, the next point should present a "better turn" than the preceding or following points
+#         next_worse = !betterturn(prevedge, query.data, currentnode.data, nextnode.data)
+#         if prev_worse && next_worse
+#             return currentnode
+#         end
+#         prev_worse = !next_worse
+#         prevnode = currentnode
+#         currentnode = nextnode
+#         nextnode = getfirst(x -> !coordsareequal(query.data, x.data), ListNodeIterator(currentnode.next; rev=false))
+#     end
+#     return currentnode
+# end
 
 
 """

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -36,10 +36,12 @@
 """
     mergehulls!(hull, otherhulls...)
 
-Merge the points contained in `otherhulls` into `hull`. See [Chan's algorithm](https://en.wikipedia.org/wiki/Chan%27s_algorithm)
+Merge the points contained in `otherhulls` into `hull`. All arguments must be
+the same concrete hull type (`MutableConvexHull`, `MutableLowerConvexHull`, or
+`MutableUpperConvexHull`). See [Chan's algorithm](https://en.wikipedia.org/wiki/Chan%27s_algorithm)
 for a similar approach.
 """
-function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
+function mergehulls!(h::H, others::H...) where H<:Union{MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull}
     mergedhull = h.hull
     mergedpoints = h.points
     
@@ -84,7 +86,7 @@ end
 Return a new convex hull containing the points of `hull` and `otherhulls`,
 without mutating any argument. See [`mergehulls!`](@ref) for the in-place form.
 """
-mergehulls(h::H, others::H...) where H <: AbstractConvexHull = mergehulls!(copy(h), others...)
+mergehulls(h::H, others::H...) where H <: Union{MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull} = mergehulls!(copy(h), others...)
 
 function merge_hull_lists!(mergedhull::AbstractList, hulltargets::Vector{<:AbstractList}, rev::Bool, orientation::HullOrientation, collinear::Bool, sortedby::Function, targetscollinear::Vector{Bool}, partial::Bool, upper::Bool)  
     try

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -88,94 +88,89 @@ without mutating any argument. See [`mergehulls!`](@ref) for the in-place form.
 """
 mergehulls(h::H, others::H...) where H <: Union{MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull} = mergehulls!(copy(h), others...)
 
-function merge_hull_lists!(mergedhull::AbstractList, hulltargets::Vector{<:AbstractList}, rev::Bool, orientation::HullOrientation, collinear::Bool, sortedby::Function, targetscollinear::Vector{Bool}, partial::Bool, upper::Bool)  
-    try
-        empty!(mergedhull) # start with an empty hull
-        # handle simple cases
-        isempty(hulltargets) && return empty!(mergedhull)
-        if length(hulltargets) == 1
-            ht = only(hulltargets)
-            if (length(ht) == 1)
-                hthead = head(ht)
-                push!(mergedhull, hthead.data)
-                addtarget!(tail(mergedhull), hthead.target)
-                return mergedhull
-            end
+function merge_hull_lists!(mergedhull::AbstractList, hulltargets::Vector{<:AbstractList}, rev::Bool, orientation::HullOrientation, collinear::Bool, sortedby::Function, targetscollinear::Vector{Bool}, partial::Bool, upper::Bool)
+    empty!(mergedhull) # start with an empty hull
+    # handle simple cases
+    isempty(hulltargets) && return empty!(mergedhull)
+    if length(hulltargets) == 1
+        ht = only(hulltargets)
+        if (length(ht) == 1)
+            hthead = head(ht)
+            push!(mergedhull, hthead.data)
+            addtarget!(tail(mergedhull), hthead.target)
+            return mergedhull
         end
-        # determine starting and stopping points for general case
-        f = x -> sortedby(x.data)
-        start = rev ? argmax(f, [head(x) for x in hulltargets]) :
-                    argmin(f, [head(x) for x in hulltargets])
-        stop = start
-        if partial
-            stop = rev ? argmin(f, [tail(x) for x in hulltargets]) :
-                        argmax(f, [tail(x) for x in hulltargets])
-        end
-        stopdata = stop.data
-
-        maxlength = sum(length, hulltargets)
-
-        # add first point to hull
-        pushfirst!(mergedhull, start.data)
-        addtarget!(head(mergedhull), start.target)
-
-        maxlength <= 1 && return mergedhull
-        
-        # prepare orientation test
-        betterturn(prevedge,o,a,b) = collinear ? iscloserturn(!orientation,prevedge,o,a,b) : isfurtherturn(!orientation,prevedge,o,a,b)
-
-        # perform jarvis march with search that makes use of the sorted nature of the hulls
-        counter = 0
-        current = start
-        currentdata = current.data
-        prevdata = currentdata
-        candidates = [head(x) for x in hulltargets]
-        prevedge = upper ? UP : DOWN
-        while counter == 0 || current !== stop
-            if counter > maxlength
-                throw(ErrorException("More points were added to the hull ($counter) than exist in the original hulls to be merged ($maxlength)."))
-            end
-            counter += 1
-            for (i, ht) in enumerate(hulltargets)
-                # candidates[i] = (current.list === ht &&                                 # If the current point belongs to the list being considered, we already know 
-                #                  !(!collinear && targetscollinear[i])) ?                # its candidate point as long as it doesn't contain extraneous collinear points.                                             
-                #     (attail(current.next) ? head(ht) : current.next) :                  # TODO: Ambiguous direction (when a subhull is entirely collinear) can cause issues           
-                #     jarvissortedsearch(current, prevedge, ht, betterturn)
-                # candidates[i] = jarvissortedsearch(current, prevedge, ht, betterturn)
-                candidates[i] = jarvissearch(current, prevedge, ListNodeIterator(ht), betterturn)
-            end
-            next = jarvissearch(current, prevedge, candidates, betterturn)
-            if coordsareequal(current.data, next.data)
-                if length(mergedhull) == 1
-                    return mergedhull
-                else
-                    throw(ErrorException("Jarvis March failed to progress."))
-                end
-            end
-            nextdata = next.data
-            # stop adding points when the stopping point has been reached
-            if coordsareequal(prevdata, nextdata) || coordsareequal(stopdata, nextdata)
-                break
-            end
-            prevdata = currentdata
-            currentdata = nextdata
-            # add the next node to the hull
-            push!(mergedhull, next.data)
-            addtarget!(tail(mergedhull), next.target)
-            prevedge = sub2d(next.data, current.data)
-            current = next
-        end
-
-        # if these are only partial convex hulls (i.e. upper or lower), add the stopping point at the end of the hull
-        if partial
-            push!(mergedhull, stop.data)
-            addtarget!(tail(mergedhull), stop.target)
-        end
-        return mergedhull
-    catch e
-        @warn("Falling back to Jarvis March for merge step due to error: $e")
-        fallback_merge_hull_lists!(mergedhull, hulltargets, rev, orientation, collinear, sortedby, targetscollinear, partial, upper)
     end
+    # determine starting and stopping points for general case
+    f = x -> sortedby(x.data)
+    start = rev ? argmax(f, [head(x) for x in hulltargets]) :
+                argmin(f, [head(x) for x in hulltargets])
+    stop = start
+    if partial
+        stop = rev ? argmin(f, [tail(x) for x in hulltargets]) :
+                    argmax(f, [tail(x) for x in hulltargets])
+    end
+    stopdata = stop.data
+
+    maxlength = sum(length, hulltargets)
+
+    # add first point to hull
+    pushfirst!(mergedhull, start.data)
+    addtarget!(head(mergedhull), start.target)
+
+    maxlength <= 1 && return mergedhull
+
+    # prepare orientation test
+    betterturn(prevedge,o,a,b) = collinear ? iscloserturn(!orientation,prevedge,o,a,b) : isfurtherturn(!orientation,prevedge,o,a,b)
+
+    # perform jarvis march with search that makes use of the sorted nature of the hulls
+    counter = 0
+    current = start
+    currentdata = current.data
+    prevdata = currentdata
+    candidates = [head(x) for x in hulltargets]
+    prevedge = upper ? UP : DOWN
+    while counter == 0 || current !== stop
+        if counter > maxlength
+            throw(ErrorException("More points were added to the hull ($counter) than exist in the original hulls to be merged ($maxlength)."))
+        end
+        counter += 1
+        for (i, ht) in enumerate(hulltargets)
+            # candidates[i] = (current.list === ht &&                                 # If the current point belongs to the list being considered, we already know
+            #                  !(!collinear && targetscollinear[i])) ?                # its candidate point as long as it doesn't contain extraneous collinear points.
+            #     (attail(current.next) ? head(ht) : current.next) :                  # TODO: Ambiguous direction (when a subhull is entirely collinear) can cause issues
+            #     jarvissortedsearch(current, prevedge, ht, betterturn)
+            # candidates[i] = jarvissortedsearch(current, prevedge, ht, betterturn)
+            candidates[i] = jarvissearch(current, prevedge, ListNodeIterator(ht), betterturn)
+        end
+        next = jarvissearch(current, prevedge, candidates, betterturn)
+        if coordsareequal(current.data, next.data)
+            if length(mergedhull) == 1
+                return mergedhull
+            else
+                throw(ErrorException("Jarvis March failed to progress."))
+            end
+        end
+        nextdata = next.data
+        # stop adding points when the stopping point has been reached
+        if coordsareequal(prevdata, nextdata) || coordsareequal(stopdata, nextdata)
+            break
+        end
+        prevdata = currentdata
+        currentdata = nextdata
+        # add the next node to the hull
+        push!(mergedhull, next.data)
+        addtarget!(tail(mergedhull), next.target)
+        prevedge = sub2d(next.data, current.data)
+        current = next
+    end
+
+    # if these are only partial convex hulls (i.e. upper or lower), add the stopping point at the end of the hull
+    if partial
+        push!(mergedhull, stop.data)
+        addtarget!(tail(mergedhull), stop.target)
+    end
+    return mergedhull
 end
 
 function merge_hull_lists!(h::AbstractChanConvexHull)

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -74,6 +74,12 @@ function mergehulls!(h::H, others::H...) where H<:AbstractConvexHull
     merge_hull_lists!(mergedhull, hulltargets, buildinreverse(h), h.orientation, h.collinear, h.sortedby, targetscollinear, partial, upper)
     return h
 end
+"""
+    mergehulls(hull, otherhulls...)
+
+Return a new convex hull containing the points of `hull` and `otherhulls`,
+without mutating any argument. See [`mergehulls!`](@ref) for the in-place form.
+"""
 mergehulls(h::H, others::H...) where H <: AbstractConvexHull = mergehulls!(copy(h), others...)
 
 function merge_hull_lists!(mergedhull::AbstractList, hulltargets::Vector{<:AbstractList}, rev::Bool, orientation::HullOrientation, collinear::Bool, sortedby::Function, targetscollinear::Vector{Bool}, partial::Bool, upper::Bool)  

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -113,15 +113,11 @@ function monotonechain!(h::MutableConvexHull{T},
     lowerhulldups = Bool[]
     hullnode = h.hull.head
     len = 0
-    # @show hullnode.data, h.hull
-    # println("Forward")
     for (i,node) in enumerate(ListNodeIterator(h.points; rev=buildinreverse(h)))
         o = len == 1 ? hullnode.data : hullnode.prev.data
         a = hullnode.data
         b = node.data
-        # println("   consider $(b)")
         if i > 1 && coordsareequal(a,b)
-            # println("      ignore equal coords: $(a), $(b)")
             push!(lowerhullidxs, i)
             push!(lowerhulldups, true)
             if hastarget(node)
@@ -130,14 +126,12 @@ function monotonechain!(h::MutableConvexHull{T},
             continue
         end
         while len >= 2 && wrongturn(o, a, b)
-            # println("      remove $(a)")
             while(lowerhulldups[end])
                 pop!(lowerhulldups)
                 pop!(lowerhullidxs)
             end
             removed = pop!(lowerhullidxs)
             pop!(lowerhulldups)
-            # println("         removed idx: $(removed)")
             hullnode = hullnode.prev
             deletenode!(hullnode.next)
             len -= 1
@@ -145,16 +139,13 @@ function monotonechain!(h::MutableConvexHull{T},
             a = hullnode.data
         end
         if !hastarget(node) # avoid overwriting the targets for points already on the hull
-            # println("      add $(b)")
             insertafter!(newnode(h.hull, b), hullnode)
             hullnode = hullnode.next
             addtarget!(hullnode, node)
         else
             if node.target === hullnode.next
-                # println("      keep $(hullnode.next.data)")
                 hullnode = hullnode.next
             else 
-                # println("      move $(node.data) to after $(hullnode.data)")
                 movednode = deletenode!(node.target)
                 insertafter!(movednode, hullnode)
                 addtarget!(movednode, node)
@@ -164,13 +155,7 @@ function monotonechain!(h::MutableConvexHull{T},
         push!(lowerhullidxs, i)
         push!(lowerhulldups, false)
         len += 1
-        # println("      lower idxs: $(lowerhullidxs)")
     end
-
-    # @show h.hull
-    # @show lowerhullidxs
-    # @show len
-    # println("Backward")
 
     lidx = length(lowerhullidxs)
     len = 1
@@ -178,23 +163,19 @@ function monotonechain!(h::MutableConvexHull{T},
         o = len == 1 ? hullnode.data : hullnode.prev.data
         a = hullnode.data
         b = node.data
-        # println("   consider $(b)")
         if lidx > 1 && i === h.points.len - lowerhullidxs[lidx] + 1
             lidx -= 1
             if node.target.prev !== hullnode
-                # println("      ignore upper hull: $(b)")
                 continue
             end
         end 
         if coordsareequal(a,b)
-            # println("      ignore equal coords: $(a), $(b)")
             if hastarget(node)
                 deletenode!(node.target)
             end
             continue
         end
         while len >= 2 && wrongturn(o, a, b)
-            # println("      remove $(a)")
             hullnode = hullnode.prev
             deletenode!(hullnode.next)
             len -= 1
@@ -202,17 +183,13 @@ function monotonechain!(h::MutableConvexHull{T},
             a = hullnode.data
         end
         if !hastarget(node) # avoid overwriting the targets for points already on the hull
-            # println("      add $(b)")
             insertafter!(newnode(h.hull, b), hullnode)
             hullnode = hullnode.next
             addtarget!(hullnode, node)
         else
-            # println("      existing hull node $(node.data)")
             if node.target === hullnode.next
-                # println("      keep $(hullnode.next.data)")
                 hullnode = hullnode.next
             elseif lidx === 1 && i === lowerhullidxs[1]
-                # println("      move $(node.data) to after $(hullnode.data)")
                 movednode = deletenode!(node.target)
                 insertafter!(movednode, hullnode)
                 addtarget!(movednode, node)
@@ -225,7 +202,6 @@ function monotonechain!(h::MutableConvexHull{T},
         end
         len += 1
     end
-    # @show h.hull
     return h
 end
 

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -208,7 +208,7 @@ end
 """
     lh = lower_monotonechain(points [; orientation, collinear, sortedby])
 
-Return the lower convex hull generated from the provided `points`.
+Return a [`MutableLowerConvexHull`](@ref) containing the lower convex hull of the provided `points`.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
@@ -234,7 +234,7 @@ lower_monotonechain(points::AbstractMatrix; kwargs...) = lower_monotonechain(row
 """
     uh = upper_monotonechain(points [; orientation, collinear, sortedby])
 
-Return the upper convex hull generated from the provided `points`.
+Return a [`MutableUpperConvexHull`](@ref) containing the upper convex hull of the provided `points`.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
@@ -260,7 +260,7 @@ upper_monotonechain(points::AbstractMatrix; kwargs...) = upper_monotonechain(row
 """
     h = monotonechain(points [; orientation, collinear, sortedby])
 
-Return the convex hull generated from the provided `points`.
+Return a [`MutableConvexHull`](@ref) containing the convex hull of the provided `points`.
 
 `points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
@@ -269,6 +269,14 @@ Return the convex hull generated from the provided `points`.
 `collinear` specifies whether collinear points are allowed along the surface of the convex hull, and defaults to `false`.
 
 `sortedby` specifies a function to apply to points prior to sorting, and defaults to `identity` (resulting in default sorting behavior).
+
+# Examples
+```jldoctest
+julia> points = [(0.0, 0.0), (1.0, 0.0), (0.5, 0.5), (1.0, 1.0), (0.0, 1.0)];
+
+julia> monotonechain(points)
+MutableConvexHull{Tuple{Float64, Float64}, typeof(identity)}((0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0))
+```
 """
 function monotonechain(points::AbstractVector{T}; orientation::HullOrientation = CCW, collinear::Bool = false, sortedby::Function = identity) where T
     pointslist = PointList{T}(;sortedby=sortedby)

--- a/src/monotonechain.jl
+++ b/src/monotonechain.jl
@@ -234,6 +234,8 @@ end
 
 Return the lower convex hull generated from the provided `points`.
 
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
+
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
 `collinear` specifies whether collinear points are allowed along the surface of the convex hull, and defaults to `false`.
@@ -251,12 +253,14 @@ function lower_monotonechain(points::AbstractVector{T}; orientation::HullOrienta
     monotonechain!(h)
     return h
 end
-lower_monotonechain(points::Matrix; kwargs...) = lower_monotonechain([(points[i,:]...,) for i=1:size(points,1)])
+lower_monotonechain(points::AbstractMatrix; kwargs...) = lower_monotonechain(rowpoints(points); kwargs...)
 
 """
     uh = upper_monotonechain(points [; orientation, collinear, sortedby])
 
 Return the upper convex hull generated from the provided `points`.
+
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -275,12 +279,14 @@ function upper_monotonechain(points::AbstractVector{T}; orientation::HullOrienta
     monotonechain!(h)
     return h
 end
-upper_monotonechain(points::Matrix; kwargs...) = upper_monotonechain([(points[i,:]...,) for i=1:size(points,1)])
+upper_monotonechain(points::AbstractMatrix; kwargs...) = upper_monotonechain(rowpoints(points); kwargs...)
 
 """
     h = monotonechain(points [; orientation, collinear, sortedby])
 
 Return the convex hull generated from the provided `points`.
+
+`points` may be a vector of points or an `AbstractMatrix` in which each row is one point.
 
 `orientation` specifies whether the points along the convex hull are ordered clockwise `CW`, or counterclockwise `CCW`, and defaults to `CCW`.
 
@@ -299,4 +305,4 @@ function monotonechain(points::AbstractVector{T}; orientation::HullOrientation =
     monotonechain!(h)
     return h
 end
-monotonechain(points::Matrix; kwargs...) = monotonechain([(points[i,:]...,) for i=1:size(points,1)])
+monotonechain(points::AbstractMatrix; kwargs...) = monotonechain(rowpoints(points); kwargs...)

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -1,4 +1,11 @@
 @enum HullOrientation CW CCW
+
+"Clockwise hull orientation: hull vertices are listed in clockwise order. See also [`CCW`](@ref)."
+CW
+
+"Counterclockwise hull orientation: hull vertices are listed in counterclockwise order. See also [`CW`](@ref)."
+CCW
+
 Base.:(!)(o::HullOrientation) = o === CCW ? CW : CCW
 
 # default previous edge direction initializations

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -5,20 +5,6 @@ Base.:(!)(o::HullOrientation) = o === CCW ? CW : CCW
 const UP = (0,1)
 const DOWN = (0,-1)
 
-# checks if a set of points are collinear
-iscollinear(prevedge, o, a) = (cross2d(prevedge, sub2d(a,o)) == 0)
-function iscollinear(points)
-    length(points) < 3 && return true
-    o = points[1]
-    a = points[2]
-    dir = sub2d(a,o)
-    for p in points[3:end]
-        iscollinear(dir, a, p) || return false
-        a = p
-    end
-    return true
-end    
-
 # The following three methods are only meant to be called if the cross product is zero. They check if the next candidate edge is aligned with the previous edge.
 isaligned(prevedge,nextedge) = dot2d(prevedge, nextedge) > 0
 function isalignedfurther(orientation, prevedge, oa, ob, ab) 

--- a/src/pointlist.jl
+++ b/src/pointlist.jl
@@ -1,5 +1,3 @@
-using PairedLinkedLists: AbstractPairedListNode, AbstractPairedSkipNode, AbstractPairedLinkedList, AbstractPairedSkipList, SkipListCache
-
 abstract type AbstractHullNode{T,L,F} <: AbstractPairedListNode{T,L} end
 abstract type AbstractHullList{T,F} <: AbstractPairedLinkedList{T} end
 abstract type AbstractPointList{T,R,N,F} <: AbstractPairedSkipList{T,F} end

--- a/src/pointlist.jl
+++ b/src/pointlist.jl
@@ -3,6 +3,13 @@ abstract type AbstractHullList{T,F} <: AbstractPairedLinkedList{T} end
 abstract type AbstractPointList{T,R,N,F} <: AbstractPairedSkipList{T,F} end
 
 
+"""
+    PointNode{T,...}
+
+A node in a [`PointList`](@ref), carrying a tracked 2-D point of type `T`. Every point passed
+to a hull — hull vertex or interior point — is stored as a `PointNode`. Accessible as
+elements of a hull's `h.points` list; iterate over them with [`MutableConvexHulls.PointNodeIterator`](@ref).
+"""
 mutable struct PointNode{T,L<:AbstractPointList{T},N<:AbstractHullNode{T}} <: AbstractPairedSkipNode{T,L}
     list::L
     data::T
@@ -31,6 +38,13 @@ mutable struct PointNode{T,L<:AbstractPointList{T},N<:AbstractHullNode{T}} <: Ab
     end
 end
 
+"""
+    PointList{T,...}
+
+A sorted skip-list of all 2-D points of type `T` tracked by a hull — hull vertices and interior
+points alike. Accessible as `h.points` on any convex hull; iterate with
+[`MutableConvexHulls.PointNodeIterator`](@ref).
+"""
 mutable struct PointList{T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Function} <: AbstractPointList{T,R,N,F}
     len::Int
     nlevels::Int
@@ -76,6 +90,12 @@ mutable struct PointList{T,R<:AbstractHullList{T},N<:AbstractHullNode{T},F<:Func
         return l
     end
 end
+"""
+    HullNode{T,...}
+
+A node in a [`HullList`](@ref), carrying one hull-vertex value of type `T`. Accessible as
+elements of a hull's `h.hull` list; iterate with [`MutableConvexHulls.HullNodeIterator`](@ref).
+"""
 mutable struct HullNode{T,L<:AbstractHullList{T},F<:Function} <: AbstractHullNode{T,L,F}
     list::L
     data::T
@@ -98,6 +118,13 @@ mutable struct HullNode{T,L<:AbstractHullList{T},F<:Function} <: AbstractHullNod
     end
 end
 
+"""
+    HullList{T,F}
+
+A doubly-linked list of hull vertices of type `T`, sorted by function `F`. Each element is a
+[`HullNode`](@ref). Accessible as `h.hull` on any convex hull; iterate with
+[`MutableConvexHulls.HullNodeIterator`](@ref), or iterate the hull directly.
+"""
 mutable struct HullList{T,F<:Function} <: AbstractHullList{T,F}
     len::Int
     target::Union{HullList{T,F}, PointList{T,HullList{T,F},HullNode{T,HullList{T,F},F},F}}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,4 @@
 # planar coordinates
-coords(data) = (data[1], data[2])
 coordsareequal(data1, data2) = data1[1] == data2[1] && data1[2] == data2[2]
 
 # 2D subtraction of data

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,11 @@
 # planar coordinates
 coordsareequal(data1, data2) = data1[1] == data2[1] && data1[2] == data2[2]
 
+# Treat each row of a matrix as one point, returning a vector of point tuples.
+# Iterates `eachrow` so rows are taken in `axes(points, 1)` order, supporting
+# views, adjoints, and matrices with non-1-based axes.
+rowpoints(points::AbstractMatrix) = [(row...,) for row in eachrow(points)]
+
 # 2D subtraction of data
 sub2d(a, b) = (DoubleFloat(a[1]) - DoubleFloat(b[1]), DoubleFloat(a[2]) - DoubleFloat(b[2]))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using PairedLinkedLists
 using Test
 using Random
 using Aqua
+using ExplicitImports
 const MCH = MutableConvexHulls
 
 Random.seed!(1234)
@@ -29,6 +30,12 @@ end
 
 @testset "Aqua" begin
     Aqua.test_all(MutableConvexHulls)
+end
+
+@testset "ExplicitImports" begin
+    test_explicit_imports(MutableConvexHulls;
+                          all_explicit_imports_are_public   = false,
+                          all_qualified_accesses_are_public = false)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,8 @@ tests = [
          "convexhull",
          "chanhull",
          "cache",
-         "testcases"
+         "testcases",
+         "generic_axes",
         ]
 
 @testset "MutableConvexHulls" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using MutableConvexHulls
 using PairedLinkedLists
 using Test
 using Random
+using Aqua
 const MCH = MutableConvexHulls
 
 Random.seed!(1234)
@@ -24,6 +25,10 @@ for t in tests
     fp = joinpath(dirname(@__FILE__), "test_$t.jl")
     println("$fp ...")
     include(fp)
+end
+
+@testset "Aqua" begin
+    Aqua.test_all(MutableConvexHulls)
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using MutableConvexHulls
 using PairedLinkedLists
 using Test
 using Random
+using Logging
 using Aqua
 using ExplicitImports
 const MCH = MutableConvexHulls

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -5,7 +5,7 @@ using MutableConvexHulls: ChanHullCache, chanhullsidentical
 function build_random_hull(H::Type{<:AbstractConvexHull}, n::Int=1024, m::Int=4; subhullcaches=true, orientation=CCW, collinear::Bool=false, sortedby=identity)
     coords = [(rand(), randn()) for i=1:n]
 
-    h = H{eltype(coords)}(orientation, collinear, sortedby)
+    h = H{eltype(coords)}(; orientation, collinear, sortedby)
     h.cache = ChanHullCache{eltype(coords)}()
     if subhullcaches
         h.subhulls[1].points.cache = SkipListCache{eltype(coords)}()

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -18,6 +18,21 @@ function build_random_hull(H::Type{<:AbstractConvexHull}, n::Int=1024, m::Int=4;
     return h
 end
 
+@testset "emptycache! with ChanHullCache" begin
+    for H in [ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull]
+        @testset "$H" begin
+            coords = [(rand(), randn()) for _ in 1:20]
+            h = H{eltype(coords)}()
+            h.cache = ChanHullCache{eltype(coords)}()
+            mergepoints!(h, coords)
+            @test !isempty(h.cache.data)
+            empty!(h)
+            @test isempty(h.cache.data)
+            @test isempty(h)
+        end
+    end
+end
+
 @testset "cache" begin
     for H in [ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull]
         for o in [CCW, CW]

--- a/test/test_cache.jl
+++ b/test/test_cache.jl
@@ -33,6 +33,15 @@ end
     end
 end
 
+@testset "copyfromcache requires an initialized cache" begin
+    for H in [ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull]
+        h = H{Tuple{Float64,Float64}}()
+        @test isnothing(h.cache)
+        @test_throws ArgumentError MutableConvexHulls.copyfromcache(h)
+        @test_throws "initialized cache" MutableConvexHulls.copyfromcache(h)
+    end
+end
+
 @testset "cache" begin
     for H in [ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull]
         for o in [CCW, CW]

--- a/test/test_chanhull.jl
+++ b/test/test_chanhull.jl
@@ -81,3 +81,32 @@ end
         end
     end
 end
+
+@testset "chan removepoint! by value and insidehull" begin
+    boxcoords = [(i, j) for i in 1:10 for j in 1:10]
+    coords = [boxcoords..., boxcoords...]   # include duplicate points
+    queries = [(i, j) for i in 0:11 for j in 0:11]   # interior, boundary, and outside
+    for (H, R, truthfun) in ((ChanLowerConvexHull, MutableLowerConvexHull, lower_jarvismarch),
+                             (ChanUpperConvexHull, MutableUpperConvexHull, upper_jarvismarch),
+                             (ChanConvexHull,      MutableConvexHull,      jarvismarch))
+        @testset "$H" begin
+            # insidehull on a Chan hull agrees with the equivalent regular hull
+            hc = H{eltype(coords)}(); mergepoints!(hc, copy(coords))
+            hr = R{eltype(coords)}(); mergepoints!(hr, copy(coords))
+            @test all(insidehull(q, hc) == insidehull(q, hr) for q in queries)
+
+            # removepoint! by value tracks the truth hull of the remaining points
+            remaining = shuffle(coords)
+            h = H{eltype(coords)}()
+            mergepoints!(h, copy(remaining))
+            for _ in 1:length(coords)
+                p = rand(remaining)
+                deleteat!(remaining, findfirst(==(p), remaining))
+                removepoint!(h, p)
+                isempty(remaining) ? (@test isempty(h)) : (@test h == truthfun(remaining))
+            end
+            # fail-fast when no contained point equals the value
+            @test_throws ArgumentError removepoint!(h, (-1, -1))
+        end
+    end
+end

--- a/test/test_chanhull.jl
+++ b/test/test_chanhull.jl
@@ -118,6 +118,10 @@ end
             hr = R{eltype(coords)}(); mergepoints!(hr, copy(coords))
             @test all(insidehull(q, hc) == insidehull(q, hr) for q in queries)
 
+            # `point in hull` delegates to insidehull on Chan hulls too
+            @test all((q in hc) == insidehull(q, hc) for q in queries)
+            @test all((q ∈ hc) == insidehull(q, hc) for q in queries)
+
             # removepoint! by value tracks the truth hull of the remaining points
             remaining = shuffle(coords)
             h = H{eltype(coords)}()

--- a/test/test_chanhull.jl
+++ b/test/test_chanhull.jl
@@ -61,3 +61,23 @@ end
         end
     end
 end
+@testset "chan hull copy" begin
+    coords = [(i + 0.5*j, j - 0.3*i) for i in 1:10 for j in 1:10]
+    for H in (ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull)
+        @testset "$H" begin
+            h = H{eltype(coords)}()
+            mergepoints!(h, coords)
+
+            hc = copy(h)
+            @test hc isa H
+            @test hc == h
+            @test hash(hc) == hash(h)
+            # the copy owns independent subhulls
+            @test all(s1 !== s2 for s1 in h.subhulls for s2 in hc.subhulls)
+            # mutating the copy leaves the original untouched
+            origverts = collect(h)
+            addpoint!(hc, (100.0, 100.0))
+            @test collect(h) == origverts
+        end
+    end
+end

--- a/test/test_chanhull.jl
+++ b/test/test_chanhull.jl
@@ -82,6 +82,29 @@ end
     end
 end
 
+@testset "chan removepoint! by HullNode" begin
+    coords = [(i, j) for i in 1:5 for j in 1:5]
+    for (H, truthfun) in ((ChanConvexHull,      jarvismarch),
+                          (ChanLowerConvexHull,  lower_jarvismarch),
+                          (ChanUpperConvexHull,  upper_jarvismarch))
+        @testset "$H" begin
+            h = H{eltype(coords)}()
+            mergepoints!(h, coords)
+            # HullNode comes from a subhull's hull list, not from h.hull
+            subhull = h.subhulls[1]
+            hullnode = subhull.hull.head.next
+            vertex = hullnode.data
+
+            h2 = H{eltype(coords)}()
+            mergepoints!(h2, coords)
+
+            removepoint!(h, hullnode)  # by HullNode (chanhull.jl dispatch)
+            removepoint!(h2, vertex)   # by value — same expected result
+            @test h == h2
+        end
+    end
+end
+
 @testset "chan removepoint! by value and insidehull" begin
     boxcoords = [(i, j) for i in 1:10 for j in 1:10]
     coords = [boxcoords..., boxcoords...]   # include duplicate points

--- a/test/test_chanhull.jl
+++ b/test/test_chanhull.jl
@@ -118,10 +118,6 @@ end
             hr = R{eltype(coords)}(); mergepoints!(hr, copy(coords))
             @test all(insidehull(q, hc) == insidehull(q, hr) for q in queries)
 
-            # `point in hull` delegates to insidehull on Chan hulls too
-            @test all((q in hc) == insidehull(q, hc) for q in queries)
-            @test all((q ∈ hc) == insidehull(q, hc) for q in queries)
-
             # removepoint! by value tracks the truth hull of the remaining points
             remaining = shuffle(coords)
             h = H{eltype(coords)}()

--- a/test/test_chanhull.jl
+++ b/test/test_chanhull.jl
@@ -24,8 +24,40 @@ end
     coords = [coords..., coords..., coords...]
     by = x -> (x[1], -x[2])
     n = 10
-    
+
     chanhulltestset("lower chan hull", n, by, coords, ChanLowerConvexHull, lower_jarvismarch)
     chanhulltestset("upper chan hull", n, by, coords, ChanUpperConvexHull, upper_jarvismarch)
     chanhulltestset("chan hull",       n, by, coords, ChanConvexHull,      jarvismarch)
+end
+
+@testset "chan hull AbstractConvexHull interface" begin
+    coords = [(i,j) for i in 1:10 for j in 1:10]
+    for H in (ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull)
+        @testset "$H" begin
+            h = H{eltype(coords)}()
+            mergepoints!(h, coords)
+            # Chan hulls participate in the AbstractConvexHull interface
+            @test h isa AbstractConvexHull{eltype(coords)}
+            @test length(h) > 0
+            @test eltype(h) === eltype(coords)
+            @test !isempty(h)
+            # show iterates the hull vertices; it must not touch a `points` field (Chan hulls lack one)
+            @test occursin(string(typeof(h)), sprint(show, h))
+            # an independently built hull over the same points compares equal
+            h2 = H{eltype(coords)}()
+            mergepoints!(h2, coords)
+            @test h == h2
+            # empty(h) yields an empty hull preserving attributes; h is untouched
+            he = empty(h)
+            @test he isa H
+            @test isempty(he)
+            @test length(h) > 0
+            @test he.orientation == h.orientation && he.collinear == h.collinear && he.sortedby == h.sortedby
+            # empty!(h) clears the hull in place and resets to a single subhull
+            empty!(h)
+            @test isempty(h)
+            @test length(h.subhulls) == 1
+            @test isempty(h.subhulls[1])
+        end
+    end
 end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -221,6 +221,37 @@ end
     end
 end
 
+@testset "Base.in delegates to insidehull" begin
+    coords = [(i, j) for i in 1:5 for j in 1:5]
+    queries = [(i, j) for i in 0:6 for j in 0:6]
+    # ∈ / in must agree with insidehull for every hull kind and collinear setting.
+    for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+        for collinear in (false, true)
+            @testset "$H collinear=$collinear" begin
+                h = H{eltype(coords)}(; orientation=CCW, collinear)
+                mergepoints!(h, coords)
+                @test all((q in h) == insidehull(q, h) for q in queries)
+                @test all((q ∈ h) == insidehull(q, h) for q in queries)
+            end
+        end
+    end
+    # The full hull of the 1:5 grid is the 1..5 square. Strictly interior points
+    # are inside and exterior points are outside regardless of `collinear`; with
+    # the default `collinear=false`, boundary points (edges and corners) are inside.
+    @testset "interior / exterior" begin
+        for collinear in (false, true)
+            h = MutableConvexHull{eltype(coords)}(; orientation=CCW, collinear)
+            mergepoints!(h, coords)
+            @test (3, 3) in h        # strictly interior
+            @test !((10, 10) in h)   # exterior
+        end
+        h = MutableConvexHull{eltype(coords)}(; orientation=CCW, collinear=false)
+        mergepoints!(h, coords)
+        @test (1, 1) in h            # corner, boundary-inclusive when collinear=false
+        @test (1, 3) in h            # edge
+    end
+end
+
 @testset "removepoint! by value, shared sortedby key" begin
     # With sortedby = first coordinate, (1,0) and (1,2) map to the same key.
     # findpointnode must scan back past one to locate the other.

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -93,6 +93,29 @@ end
     end
 end
 
+@testset "constructor keyword API" begin
+    # All configuration arguments are keyword-only; positional calls now throw.
+    T = Tuple{Float64,Float64}
+    by = x -> x[1]
+    for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+        # Defaults
+        h = H{T}()
+        @test h.orientation === CCW && h.collinear === false && h.sortedby === identity
+        # All keywords explicit
+        h2 = H{T}(; orientation=CW, collinear=true, sortedby=by)
+        @test h2.orientation === CW && h2.collinear === true && h2.sortedby === by
+        # Positional call now throws
+        @test_throws MethodError H{T}(CCW, false, identity)
+    end
+    for H in (ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull)
+        h = H{T}()
+        @test h.orientation === CCW && h.collinear === false && h.sortedby === identity
+        h2 = H{T}(; orientation=CW, collinear=true, sortedby=by)
+        @test h2.orientation === CW && h2.collinear === true && h2.sortedby === by
+        @test_throws MethodError H{T}(CCW, false, identity)
+    end
+end
+
 @testset "removepoint! by value" begin
     boxcoords = [(i, j) for i in 1:10 for j in 1:10]
     coords = [boxcoords..., boxcoords...]   # include duplicate points
@@ -186,7 +209,7 @@ end
     coords = [(i, j) for i in 1:5 for j in 1:5]
     for collinear in (false, true)
         @testset "collinear=$collinear" begin
-            h = MutableConvexHull{eltype(coords)}(CCW, collinear)
+            h = MutableConvexHull{eltype(coords)}(; orientation=CCW, collinear)
             mergepoints!(h, coords)
             # Strictly interior and exterior points are unaffected by the collinear flag.
             @test insidehull((3, 3), h) == true
@@ -207,7 +230,7 @@ end
                           (MutableLowerConvexHull,  lower_jarvismarch),
                           (MutableUpperConvexHull,  upper_jarvismarch))
         @testset "$H" begin
-            h = H{eltype(pts), typeof(sb)}(CCW, false, sb)
+            h = H{eltype(pts), typeof(sb)}(; orientation=CCW, collinear=false, sortedby=sb)
             for p in pts
                 addpoint!(h, p)
             end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -135,6 +135,84 @@ end
             # collecting yields a vector typed by that eltype
             @test collect(hulliter) isa Vector{eltype(hulliter)}
             @test collect(pointiter) isa Vector{eltype(pointiter)}
+
+            # node-based HullNodeIterator constructor: starting from a specific node
+            # produces the same suffix as collecting from that position in the full hull
+            allnodes = collect(MCH.HullNodeIterator(h))
+            @test collect(MCH.HullNodeIterator(allnodes[1])) == allnodes
+            length(allnodes) >= 2 &&
+                @test collect(MCH.HullNodeIterator(allnodes[2])) == allnodes[2:end]
+        end
+    end
+end
+
+@testset "removepoint! by HullNode" begin
+    coords = [(i, j) for i in 1:5 for j in 1:5]
+    for (H, truthfun) in ((MutableLowerConvexHull, lower_jarvismarch),
+                          (MutableUpperConvexHull, upper_jarvismarch),
+                          (MutableConvexHull,      jarvismarch))
+        @testset "$H" begin
+            h = H{eltype(coords)}()
+            mergepoints!(h, coords)
+            hullnode = h.hull.head.next
+            vertex = hullnode.data
+
+            h2 = H{eltype(coords)}()
+            mergepoints!(h2, coords)
+
+            removepoint!(h, hullnode)  # by HullNode
+            removepoint!(h2, vertex)   # by value — same expected result
+            @test h == h2
+        end
+    end
+end
+
+@testset "mergepoints! Matrix input" begin
+    coords = [(i, j) for i in 1:5 for j in 1:5]
+    m = [p[k] for p in coords, k in 1:2]
+    for H in (MutableLowerConvexHull, MutableUpperConvexHull, MutableConvexHull)
+        @testset "$H" begin
+            h_vec = H{eltype(coords)}(); mergepoints!(h_vec, coords)
+            h_mat = H{eltype(coords)}(); mergepoints!(h_mat, m)
+            @test h_vec == h_mat
+        end
+    end
+end
+
+@testset "insidehull with AbstractNode" begin
+    # The convex hull of the 5×5 grid is the corner rectangle.
+    # Pass hull nodes directly (the AbstractNode dispatch) and verify the inside/outside
+    # result, including the collinear boundary behaviour.
+    coords = [(i, j) for i in 1:5 for j in 1:5]
+    for collinear in (false, true)
+        @testset "collinear=$collinear" begin
+            h = MutableConvexHull{eltype(coords)}(CCW, collinear)
+            mergepoints!(h, coords)
+            # Strictly interior and exterior points are unaffected by the collinear flag.
+            @test insidehull((3, 3), h) == true
+            @test insidehull((10, 10), h) == false
+            # h.hull.head.next is the bottom-left corner (1,1), on the hull boundary.
+            # With collinear=false the ≥ test includes the boundary; with collinear=true the > does not.
+            @test insidehull(h.hull.head.next, h) == !collinear
+        end
+    end
+end
+
+@testset "removepoint! by value, shared sortedby key" begin
+    # With sortedby = first coordinate, (1,0) and (1,2) map to the same key.
+    # findpointnode must scan back past one to locate the other.
+    sb = x -> x[1]
+    pts = [(0, 1), (2, 1), (1, 0), (1, 2)]
+    for (H, truthfun) in ((MutableConvexHull,      jarvismarch),
+                          (MutableLowerConvexHull,  lower_jarvismarch),
+                          (MutableUpperConvexHull,  upper_jarvismarch))
+        @testset "$H" begin
+            h = H{eltype(pts), typeof(sb)}(CCW, false, sb)
+            for p in pts
+                addpoint!(h, p)
+            end
+            removepoint!(h, (1, 0))
+            @test h == truthfun(filter(!=((1, 0)), pts); sortedby=sb)
         end
     end
 end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -28,3 +28,65 @@ end
     hulltestset("upper convex hull", n, by, coords, MutableUpperConvexHull, upper_jarvismarch)
     hulltestset("convex hull",       n, by, coords, MutableConvexHull,      jarvismarch)
 end
+@testset "hash, copy, and mergehulls" begin
+    coords = [(randn(), randn()) for _ in 1:50]
+    for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+        @testset "$H" begin
+            h = H{eltype(coords)}()
+            for p in coords
+                addpoint!(h, p)
+            end
+
+            # hash is consistent with `==`: equal hulls hash equally
+            h2 = H{eltype(coords)}()
+            for p in coords
+                addpoint!(h2, p)
+            end
+            @test h == h2
+            @test hash(h) == hash(h2)
+            # usable as Set elements / Dict keys
+            @test length(Set([h, h2])) == 1
+            @test (Dict(h => 1)[h2]) == 1
+
+            # copy is equal and independent
+            hc = copy(h)
+            @test hc == h
+            @test hash(hc) == hash(h)
+            @test hc isa H
+            # no linked-list nodes are shared between original and copy
+            @test !any(n1 === n2 for n1 in PointNodeIterator(h) for n2 in PointNodeIterator(hc))
+            # mutating the copy leaves the original untouched, and vice versa
+            origverts = collect(h)
+            removepoint!(hc, hc.points.head.next)
+            @test collect(h) == origverts
+            copyverts = collect(hc)
+            removepoint!(h, h.points.head.next)
+            @test collect(hc) == copyverts
+
+            # copying an empty hull yields an empty, independent hull
+            empt = H{eltype(coords)}()
+            ec = copy(empt)
+            @test isempty(ec)
+            @test ec == empt
+        end
+    end
+
+    # mergehulls returns the merged hull without mutating its arguments
+    @testset "mergehulls is non-mutating" begin
+        a = MutableConvexHull{Tuple{Float64,Float64}}()
+        b = MutableConvexHull{Tuple{Float64,Float64}}()
+        for p in [(0.0,0.0),(1.0,0.0),(1.0,1.0),(0.0,1.0)]
+            addpoint!(a, p)
+        end
+        for p in [(2.0,2.0),(3.0,2.0),(3.0,3.0),(2.0,3.0)]
+            addpoint!(b, p)
+        end
+        averts = collect(a)
+        bverts = collect(b)
+        m = MCH.mergehulls(a, b)
+        @test collect(a) == averts
+        @test collect(b) == bverts
+        merged = mergehulls!(copy(a), copy(b))
+        @test m == merged
+    end
+end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -54,7 +54,7 @@ end
             @test hash(hc) == hash(h)
             @test hc isa H
             # no linked-list nodes are shared between original and copy
-            @test !any(n1 === n2 for n1 in PointNodeIterator(h) for n2 in PointNodeIterator(hc))
+            @test !any(n1 === n2 for n1 in MCH.PointNodeIterator(h) for n2 in MCH.PointNodeIterator(hc))
             # mutating the copy leaves the original untouched, and vice versa
             origverts = collect(h)
             removepoint!(hc, hc.points.head.next)
@@ -112,6 +112,29 @@ end
             end
             # fail-fast when no contained point equals the value
             @test_throws ArgumentError removepoint!(h, (-1, -1))
+        end
+    end
+end
+
+@testset "node iterator eltype" begin
+    coords = [(i, j) for i in 1:5 for j in 1:5]
+    for H in (MutableLowerConvexHull, MutableUpperConvexHull, MutableConvexHull)
+        @testset "$H" begin
+            h = H{eltype(coords)}()
+            mergepoints!(h, coords)
+
+            hulliter = MCH.HullNodeIterator(h)
+            pointiter = MCH.PointNodeIterator(h)
+
+            # eltype reports the concrete node type rather than `Any`
+            @test eltype(hulliter) === MCH.nodetype(h.hull) !== Any
+            @test eltype(pointiter) === MCH.nodetype(h.points) !== Any
+            @test Base.IteratorEltype(hulliter) === Base.HasEltype()
+            @test Base.IteratorEltype(pointiter) === Base.HasEltype()
+
+            # collecting yields a vector typed by that eltype
+            @test collect(hulliter) isa Vector{eltype(hulliter)}
+            @test collect(pointiter) isa Vector{eltype(pointiter)}
         end
     end
 end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -83,10 +83,35 @@ end
         end
         averts = collect(a)
         bverts = collect(b)
-        m = MCH.mergehulls(a, b)
+        # `mergehulls` is exported, so it is callable unqualified
+        @test :mergehulls in names(MutableConvexHulls)
+        m = mergehulls(a, b)
         @test collect(a) == averts
         @test collect(b) == bverts
         merged = mergehulls!(copy(a), copy(b))
         @test m == merged
+    end
+end
+
+@testset "removepoint! by value" begin
+    boxcoords = [(i, j) for i in 1:10 for j in 1:10]
+    coords = [boxcoords..., boxcoords...]   # include duplicate points
+    for (H, truthfun) in ((MutableLowerConvexHull, lower_jarvismarch),
+                          (MutableUpperConvexHull, upper_jarvismarch),
+                          (MutableConvexHull, jarvismarch))
+        @testset "$H" begin
+            remaining = shuffle(coords)
+            h = H{eltype(coords)}()
+            mergepoints!(h, copy(remaining))
+            for _ in 1:length(coords)
+                p = rand(remaining)
+                # drop one instance from the reference multiset, then by value from the hull
+                deleteat!(remaining, findfirst(==(p), remaining))
+                removepoint!(h, p)
+                isempty(remaining) ? (@test isempty(h)) : (@test h == truthfun(remaining))
+            end
+            # fail-fast when no contained point equals the value
+            @test_throws ArgumentError removepoint!(h, (-1, -1))
+        end
     end
 end

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -91,6 +91,17 @@ end
         merged = mergehulls!(copy(a), copy(b))
         @test m == merged
     end
+
+    @testset "mergehulls! rejects Chan hulls" begin
+        # Chan hulls lack a .points field; they must not silently crash with a
+        # field-access error — the caller should get a MethodError instead.
+        T = Tuple{Float64,Float64}
+        for H in (ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull)
+            h = H{T}()
+            @test_throws MethodError mergehulls!(h, h)
+            @test_throws MethodError mergehulls(h, h)
+        end
+    end
 end
 
 @testset "constructor keyword API" begin

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -2,7 +2,7 @@
     boxcoords = [(i,j) for i in 1:10 for j in 1:10]
     by = x -> (x[1], -x[2])
     n = 10
-    
+
     hulltestset("lower convex hull", n, by, boxcoords, MutableLowerConvexHull, lower_jarvismarch)
     hulltestset("upper convex hull", n, by, boxcoords, MutableUpperConvexHull, upper_jarvismarch)
     hulltestset("convex hull",       n, by, boxcoords, MutableConvexHull,      jarvismarch)
@@ -13,7 +13,7 @@ end
     boxcoords = [boxcoords..., boxcoords..., boxcoords...]
     by = x -> (x[1], -x[2])
     n = 10
-    
+
     hulltestset("lower convex hull", n, by, boxcoords, MutableLowerConvexHull, lower_jarvismarch)
     hulltestset("upper convex hull", n, by, boxcoords, MutableUpperConvexHull, upper_jarvismarch)
     hulltestset("convex hull",       n, by, boxcoords, MutableConvexHull,      jarvismarch)
@@ -23,7 +23,7 @@ end
     coords = [(randn(),randn()) for i in 1:10 for j in 1:10]
     by = x -> (x[1], -x[2])
     n = 10
-    
+
     hulltestset("lower convex hull", n, by, coords, MutableLowerConvexHull, lower_jarvismarch)
     hulltestset("upper convex hull", n, by, coords, MutableUpperConvexHull, upper_jarvismarch)
     hulltestset("convex hull",       n, by, coords, MutableConvexHull,      jarvismarch)
@@ -241,41 +241,51 @@ end
             # Strictly interior and exterior points are unaffected by the collinear flag.
             @test insidehull((3, 3), h) == true
             @test insidehull((10, 10), h) == false
-            # h.hull.head.next is the bottom-left corner (1,1), on the hull boundary.
-            # With collinear=false the ≥ test includes the boundary; with collinear=true the > does not.
-            @test insidehull(h.hull.head.next, h) == !collinear
+            # h.hull.head.next is the bottom-left corner (1,1), an exact hull vertex.
+            # Exact vertex matches are always inside regardless of collinear.
+            @test insidehull(h.hull.head.next, h)
         end
     end
 end
 
-@testset "Base.in delegates to insidehull" begin
+@testset "insidehull interior / exterior / boundary" begin
     coords = [(i, j) for i in 1:5 for j in 1:5]
-    queries = [(i, j) for i in 0:6 for j in 0:6]
-    # ∈ / in must agree with insidehull for every hull kind and collinear setting.
-    for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+    # With collinear=false the hull is the 4-corner square; with collinear=true it
+    # includes all collinear boundary grid points as explicit vertices.
+    for collinear in (false, true)
+        h = MutableConvexHull{eltype(coords)}(; orientation=CCW, collinear)
+        mergepoints!(h, coords)
+        @test insidehull((3, 3), h)                 # strictly interior
+        @test !insidehull((10, 10), h)              # exterior
+        @test insidehull((1, 1), h)                 # corner vertex: always inside regardless of collinear
+        # (1,3) is in the input data: a hull vertex when collinear=true, an edge point when
+        # collinear=false.  In both cases insidehull returns true.
+        @test insidehull((1, 3), h)
+    end
+
+    # Non-vertex boundary points (not in the input data): inside when collinear=false,
+    # outside when collinear=true.
+    fcoords = [(Float64(i), Float64(j)) for i in 1:5 for j in 1:5]
+    for collinear in (false, true)
+        hf = MutableConvexHull{eltype(fcoords)}(; orientation=CCW, collinear)
+        mergepoints!(hf, fcoords)
+        @test insidehull((1.0, 2.5), hf) != collinear    # left edge, between (1,2) and (1,3)
+    end
+end
+
+@testset "insidehull collinear: interior hull vertices always inside" begin
+    # Hull vertices that are not on vertical extreme edges previously returned false
+    # with collinear=true.  All hull vertices must return true regardless of collinear.
+    pts = [(0.0,1.0), (2.0,0.0), (4.0,1.0), (3.0,3.0), (1.0,3.0)]
+    for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull,
+              ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull)
         for collinear in (false, true)
-            @testset "$H collinear=$collinear" begin
-                h = H{eltype(coords)}(; orientation=CCW, collinear)
-                mergepoints!(h, coords)
-                @test all((q in h) == insidehull(q, h) for q in queries)
-                @test all((q ∈ h) == insidehull(q, h) for q in queries)
+            h = H{eltype(pts)}(; collinear)
+            for p in pts; addpoint!(h, p); end
+            for v in collect(h)
+                @test insidehull(v, h)
             end
         end
-    end
-    # The full hull of the 1:5 grid is the 1..5 square. Strictly interior points
-    # are inside and exterior points are outside regardless of `collinear`; with
-    # the default `collinear=false`, boundary points (edges and corners) are inside.
-    @testset "interior / exterior" begin
-        for collinear in (false, true)
-            h = MutableConvexHull{eltype(coords)}(; orientation=CCW, collinear)
-            mergepoints!(h, coords)
-            @test (3, 3) in h        # strictly interior
-            @test !((10, 10) in h)   # exterior
-        end
-        h = MutableConvexHull{eltype(coords)}(; orientation=CCW, collinear=false)
-        mergepoints!(h, coords)
-        @test (1, 1) in h            # corner, boundary-inclusive when collinear=false
-        @test (1, 3) in h            # edge
     end
 end
 

--- a/test/test_convexhull.jl
+++ b/test/test_convexhull.jl
@@ -102,6 +102,22 @@ end
             @test_throws MethodError mergehulls(h, h)
         end
     end
+
+    @testset "merge_hull_lists! emits no fallback warning" begin
+        # The optimized merge path must never silently fall back on valid input.
+        pts_a = [(Float64(i), Float64(j)) for i in 1:5 for j in 1:5]
+        pts_b = [(Float64(i), Float64(j)) for i in 6:10 for j in 1:5]
+        for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+            a = H{eltype(pts_a)}(); mergepoints!(a, pts_a)
+            b = H{eltype(pts_b)}(); mergepoints!(b, pts_b)
+            @test_logs min_level=Logging.Warn mergehulls!(copy(a), copy(b))
+        end
+        for H in (ChanConvexHull, ChanLowerConvexHull, ChanUpperConvexHull)
+            h = H{Tuple{Float64,Float64}}()
+            mergepoints!(h, [pts_a..., pts_b...])
+            @test_logs min_level=Logging.Warn mergepoints!(h, [(11.0, Float64(j)) for j in 1:5])
+        end
+    end
 end
 
 @testset "constructor keyword API" begin

--- a/test/test_funs.jl
+++ b/test/test_funs.jl
@@ -82,7 +82,7 @@ function removetests(n, by, coords, hullfun, truthfun)
                 removeddata = shuffledcoords[removeidx]
                 deleteat!(shuffledcoords, removeidx)
                 for h in hulls
-                    removepoint!(h, getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.target)))
+                    removepoint!(h, MCH.getfirst(x -> x.data == removeddata, ListNodeIterator(h.hull.target)))
                     @test h == truthfun(shuffledcoords; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby)
                 end
             end
@@ -159,7 +159,7 @@ function chanremovetests(n, by, coords, hullfun, truthfun)
                 for h in hulls
                     rmnode = first(h.subhulls).points.head
                     for sh in h.subhulls
-                        rmnode = getfirst(x -> x.data == removeddata, ListNodeIterator(sh.points))
+                        rmnode = MCH.getfirst(x -> x.data == removeddata, ListNodeIterator(sh.points))
                         !isnothing(rmnode) && break
                     end
                     removepoint!(h, rmnode)

--- a/test/test_funs.jl
+++ b/test/test_funs.jl
@@ -38,7 +38,7 @@ function addtests(n, by, coords, hullfun, truthfun)
     @testset "add points" begin
         for j=1:n
             shuffledcoords = shuffle(coords)
-            hulls = [hullfun{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
+            hulls = [hullfun{eltype(shuffledcoords)}(; orientation=o, collinear=c, sortedby=f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
             for (i, coord) in enumerate(shuffledcoords)
                 for h in hulls
                     addpoint!(h, coord)
@@ -56,7 +56,7 @@ function mergetests(n, by, coords, hullfun, truthfun)
             mergesize = Int(ceil((sqrt(length(coords))/10)))
             nummerges = Int(length(coords)/mergesize) # have to choose a size of the coords that is divisible by 10
             splitcoords = [shuffledcoords[mergesize*(i-1)+1:mergesize*i] for i=1:nummerges]
-            hulls = [hullfun{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
+            hulls = [hullfun{eltype(shuffledcoords)}(; orientation=o, collinear=c, sortedby=f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
             mergedcoords = eltype(coords)[]
             for scoords in splitcoords
                 append!(mergedcoords, scoords)
@@ -73,7 +73,7 @@ function removetests(n, by, coords, hullfun, truthfun)
     @testset "remove points" begin
         for j=1:n
             shuffledcoords = shuffle(coords)
-            hulls = [hullfun{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
+            hulls = [hullfun{eltype(shuffledcoords)}(; orientation=o, collinear=c, sortedby=f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
             for h in hulls
                 mergepoints!(h, shuffledcoords)
             end
@@ -118,14 +118,14 @@ function fallbackmergetest(n, by, coords, hullfun, truthfun)
             mergesize = Int(ceil((sqrt(length(coords))/10)))
             nummerges = Int(length(coords)/mergesize) # have to choose a size of the coords that is divisible by 10
             splitcoords = [shuffledcoords[mergesize*(i-1)+1:mergesize*i] for i=1:nummerges]
-            hulls = [hullfun{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
+            hulls = [hullfun{eltype(shuffledcoords)}(; orientation=o, collinear=c, sortedby=f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
             mergedcoords = eltype(coords)[]
             for scoords in splitcoords
                 append!(mergedcoords, scoords)
                 for h in hulls
                     npoints = sum(length, h.subhulls)
                     while npoints > 3 && length(h.subhulls)^2 < npoints
-                        push!(h.subhulls, eltype(h.subhulls)(h.orientation, h.collinear, h.sortedby))
+                        push!(h.subhulls, eltype(h.subhulls)(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby))
                         if (h.subhulls[1].points.cache !== nothing)
                             h.subhulls[end].points.cache = PairedLinkedLists.SkipListCache{T}()
                         end
@@ -144,7 +144,7 @@ function chanremovetests(n, by, coords, hullfun, truthfun)
     @testset "remove point" begin
         for j=1:n
             shuffledcoords = shuffle(coords)
-            hulls = [hullfun{eltype(shuffledcoords)}(o, c, f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
+            hulls = [hullfun{eltype(shuffledcoords)}(; orientation=o, collinear=c, sortedby=f) for o in [CCW,CW] for c in [false,true] for f in [identity, by]]
             for h in hulls
                 mergesize = Int(ceil((sqrt(length(shuffledcoords))/10)))
                 nummerges = Int(length(shuffledcoords)/mergesize) # have to choose a size of the coords that is divisible by 10

--- a/test/test_funs.jl
+++ b/test/test_funs.jl
@@ -17,7 +17,7 @@ function inittest(by, coords, hullfun)
         hull = HullList{eltype(coords)}(;sortedby=by)
         points = PointList{eltype(coords)}(;sortedby=by)
         addtarget!(hull, points)
-        h2 = hullfun{eltype(coords), typeof(by)}(hull, points, CW, true, by)
+        @test hullfun{eltype(coords), typeof(by)}(hull, points, CW, true, by) isa hullfun
     end
 end
 
@@ -123,13 +123,7 @@ function fallbackmergetest(n, by, coords, hullfun, truthfun)
             for scoords in splitcoords
                 append!(mergedcoords, scoords)
                 for h in hulls
-                    npoints = sum(length, h.subhulls)
-                    while npoints > 3 && length(h.subhulls)^2 < npoints
-                        push!(h.subhulls, eltype(h.subhulls)(; orientation=h.orientation, collinear=h.collinear, sortedby=h.sortedby))
-                        if (h.subhulls[1].points.cache !== nothing)
-                            h.subhulls[end].points.cache = PairedLinkedLists.SkipListCache{T}()
-                        end
-                    end
+                    MutableConvexHulls.growsubhulls!(h)
                     smallhull = argmin(x->length(x.points),h.subhulls)
                     mergepoints!(smallhull, scoords)
                     MutableConvexHulls.fallback_merge_hull_lists!(h)

--- a/test/test_generic_axes.jl
+++ b/test/test_generic_axes.jl
@@ -37,4 +37,35 @@
             end
         end
     end
+
+    @testset "matrix input" begin
+        # row-as-point matrix matching `pts`
+        pmat = [p[k] for p in pts, k in 1:2]
+        # column-as-point matrix; its adjoint is a lazy row-as-point matrix
+        cmat = [p[k] for k in 1:2, p in pts]
+
+        # shifted-axes wrapper (sharpest test: exercises non-1-based row indexing)
+        ompat = OffsetArray(pmat, -10, -2)
+        # lazy wrappers (catch Array-ness / contiguity assumptions)
+        vmat = view(pmat, :, :)
+        amat = cmat'
+
+        for (label, input) in (("offset", ompat), ("view", vmat), ("adjoint", amat))
+            @testset "$label input" begin
+                @test monotonechain(input)       == monotonechain(pts)
+                @test lower_monotonechain(input) == lower_monotonechain(pts)
+                @test upper_monotonechain(input) == upper_monotonechain(pts)
+                @test jarvismarch(input)         == jarvismarch(pts)
+                @test lower_jarvismarch(input)   == lower_jarvismarch(pts)
+                @test upper_jarvismarch(input)   == upper_jarvismarch(pts)
+
+                let ref = MutableConvexHull{eltype(pts)}()
+                    mergepoints!(ref, pts)
+                    h = MutableConvexHull{eltype(pts)}()
+                    mergepoints!(h, input)
+                    @test h == ref
+                end
+            end
+        end
+    end
 end

--- a/test/test_generic_axes.jl
+++ b/test/test_generic_axes.jl
@@ -1,0 +1,40 @@
+@testset "generic axes" begin
+    using OffsetArrays
+
+    pts = [(i, j) for i in 1:5 for j in 1:5]
+
+    # shifted-axes wrapper (sharpest test: exercises non-1-based indexing)
+    opts = OffsetArray(pts, -10)
+    # lazy wrapper (catches Array-ness / contiguity assumptions)
+    vpts = view(pts, :)
+
+    for (label, input) in (("offset", opts), ("view", vpts))
+        @testset "$label input" begin
+            @test monotonechain(input)       == monotonechain(pts)
+            @test lower_monotonechain(input) == lower_monotonechain(pts)
+            @test upper_monotonechain(input) == upper_monotonechain(pts)
+            @test jarvismarch(input)         == jarvismarch(pts)
+            @test lower_jarvismarch(input)   == lower_jarvismarch(pts)
+            @test upper_jarvismarch(input)   == upper_jarvismarch(pts)
+
+            let ref = MutableConvexHull{eltype(pts)}()
+                mergepoints!(ref, pts)
+                h = MutableConvexHull{eltype(pts)}()
+                mergepoints!(h, input)
+                @test h == ref
+            end
+            let ref = MutableLowerConvexHull{eltype(pts)}()
+                mergepoints!(ref, pts)
+                h = MutableLowerConvexHull{eltype(pts)}()
+                mergepoints!(h, input)
+                @test h == ref
+            end
+            let ref = MutableUpperConvexHull{eltype(pts)}()
+                mergepoints!(ref, pts)
+                h = MutableUpperConvexHull{eltype(pts)}()
+                mergepoints!(h, input)
+                @test h == ref
+            end
+        end
+    end
+end

--- a/test/test_jarvismarch.jl
+++ b/test/test_jarvismarch.jl
@@ -113,4 +113,13 @@
             @test MCH.jarvismarch!(h1) isa H
         end
     end
+
+    @testset "jarvismarch! rejects an empty hull" begin
+        T = Tuple{Int,Int}
+        for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+            h = H{T}()
+            @test_throws ArgumentError MCH.jarvismarch!(h.hull, h.hull.target, h.collinear, h.orientation, MCH.DOWN)
+            @test_throws "at least one point" MCH.jarvismarch!(h.hull, h.hull.target, h.collinear, h.orientation, MCH.DOWN)
+        end
+    end
 end

--- a/test/test_jarvismarch.jl
+++ b/test/test_jarvismarch.jl
@@ -44,7 +44,7 @@
         uppercollinear = upper_jarvismarch(boxcoords; collinear = true)
         uppercollinearCW = upper_jarvismarch(boxcoords; orientation=CW, collinear=true)
         @test collect(uppercollinear.hull) == [[(i,last(jrange)) for i in reverse(irange)]..., [(first(irange), j) for j in reverse(jrange)[2:end]]...]
-        @test collect(uppercollinearCW) == reverse(collect(uppercollinear.hull))
+        @test collect(uppercollinearCW.hull) == reverse(collect(uppercollinear.hull))
         for u in [upper, upperCW, uppercollinear, uppercollinearCW]
             @test collect(u.hull) == collect(MCH.jarvismarch!(u).hull)
         end

--- a/test/test_jarvismarch.jl
+++ b/test/test_jarvismarch.jl
@@ -90,4 +90,16 @@
             @test collect(h.hull) == collect(MCH.jarvismarch!(h).hull)
         end
     end
+
+    @testset "Matrix input" begin
+        m = [p[k] for p in boxcoords, k in 1:2]
+        @test lower_jarvismarch(m) == lower_jarvismarch(boxcoords)
+        @test upper_jarvismarch(m) == upper_jarvismarch(boxcoords)
+        @test jarvismarch(m)       == jarvismarch(boxcoords)
+
+        # configuration keywords are forwarded through the matrix form
+        @test collect(jarvismarch(m; orientation=CW).hull) == collect(jarvismarch(boxcoords; orientation=CW).hull)
+        @test collect(lower_jarvismarch(m; collinear=true).hull) == collect(lower_jarvismarch(boxcoords; collinear=true).hull)
+        @test collect(upper_jarvismarch(m; sortedby=by).hull) == collect(upper_jarvismarch(boxcoords; sortedby=by).hull)
+    end
 end

--- a/test/test_jarvismarch.jl
+++ b/test/test_jarvismarch.jl
@@ -102,4 +102,15 @@
         @test collect(lower_jarvismarch(m; collinear=true).hull) == collect(lower_jarvismarch(boxcoords; collinear=true).hull)
         @test collect(upper_jarvismarch(m; sortedby=by).hull) == collect(upper_jarvismarch(boxcoords; sortedby=by).hull)
     end
+
+    @testset "jarvismarch! return type — 0 and 1 point" begin
+        T = Tuple{Int,Int}
+        for H in (MutableConvexHull, MutableLowerConvexHull, MutableUpperConvexHull)
+            h0 = H{T}()
+            @test MCH.jarvismarch!(h0) isa H
+            h1 = H{T}()
+            addpoint!(h1, (1, 1))
+            @test MCH.jarvismarch!(h1) isa H
+        end
+    end
 end

--- a/test/test_monotonechain.jl
+++ b/test/test_monotonechain.jl
@@ -56,7 +56,7 @@
         hull = monotonechain(boxcoords) # ; orientation = CCW, collinear = false
         @test hull == monotonechain(dupcoords)
         @test collect(hull.hull) == collect(monotonechain(boxcoords).hull) == [first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords), (first(boxcoords)[1], last(boxcoords)[2])]
-        @test collect(monotonechain(boxcoords; orientation=CW).hull) == reverse(circshift(collect(hull.hull),Int(length(hull.hull)/2-1))) 
+        @test collect(monotonechain(boxcoords; orientation=CW).hull) == reverse(circshift(collect(hull.hull),Int(length(hull.hull)/2-1)))
         hullcollinear = monotonechain(boxcoords; collinear = true)
         @test hullcollinear == monotonechain(dupcoords; collinear = true)
         @test collect(hullcollinear.hull) == collect(monotonechain(boxcoords; collinear=true).hull) == [[(i,first(jrange)) for i in irange]..., [(last(irange), j) for j in jrange[2:end]]..., [(i,last(jrange)) for i in reverse(irange)[2:end]]..., [(first(irange), j) for j in reverse(jrange)[2:end-1]]...]
@@ -66,10 +66,17 @@
         hull2 = monotonechain(boxcoords; sortedby=by) # ; orientation = CCW, collinear = false
         @test hull2 == monotonechain(dupcoords; sortedby=by)
         @test collect(hull2.hull) == [(first(boxcoords)[1], last(boxcoords)[2]), first(boxcoords), (last(boxcoords)[1], first(boxcoords)[2]), last(boxcoords)]
-        @test collect(monotonechain(boxcoords; orientation=CW, sortedby=by).hull) == reverse(circshift(collect(hull2.hull),Int(length(hull2.hull)/2-1))) 
+        @test collect(monotonechain(boxcoords; orientation=CW, sortedby=by).hull) == reverse(circshift(collect(hull2.hull),Int(length(hull2.hull)/2-1)))
         hullcollinear2 = monotonechain(boxcoords; collinear=true, sortedby=by)
         @test hullcollinear2 == monotonechain(dupcoords; collinear=true, sortedby=by)
         @test collect(hullcollinear2.hull) == [[(first(jrange),i) for i in reverse(irange)]..., [(j,first(irange)) for j in jrange[2:end]]..., [(last(jrange),i) for i in irange[2:end]]..., [(j,last(irange)) for j in reverse(jrange)[2:end-1]]...]
-        @test collect(monotonechain(boxcoords; orientation=CW, collinear=true, sortedby=by).hull) == reverse(circshift(collect(hullcollinear2.hull),Int(length(hullcollinear2.hull)/2-1))) 
+        @test collect(monotonechain(boxcoords; orientation=CW, collinear=true, sortedby=by).hull) == reverse(circshift(collect(hullcollinear2.hull),Int(length(hullcollinear2.hull)/2-1)))
+    end
+
+    @testset "Matrix input" begin
+        m = [p[k] for p in boxcoords, k in 1:2]
+        @test lower_monotonechain(m) == lower_monotonechain(boxcoords)
+        @test upper_monotonechain(m) == upper_monotonechain(boxcoords)
+        @test monotonechain(m)       == monotonechain(boxcoords)
     end
 end

--- a/test/test_monotonechain.jl
+++ b/test/test_monotonechain.jl
@@ -78,5 +78,10 @@
         @test lower_monotonechain(m) == lower_monotonechain(boxcoords)
         @test upper_monotonechain(m) == upper_monotonechain(boxcoords)
         @test monotonechain(m)       == monotonechain(boxcoords)
+
+        # configuration keywords are forwarded through the matrix form
+        @test collect(monotonechain(m; orientation=CW).hull) == collect(monotonechain(boxcoords; orientation=CW).hull)
+        @test collect(lower_monotonechain(m; collinear=true).hull) == collect(lower_monotonechain(boxcoords; collinear=true).hull)
+        @test collect(upper_monotonechain(m; sortedby=by).hull) == collect(upper_monotonechain(boxcoords; sortedby=by).hull)
     end
 end

--- a/test/test_testcases.jl
+++ b/test/test_testcases.jl
@@ -12,7 +12,7 @@
         [(-6.2439818800893345, -0.04246981487863836), (-6.212466543837844, -0.062191469382781084), (-4.825781500808825, -0.18387287334976443), (-2.9043631254765314, -0.06217652402829946), (-1.9524199699468225, -1.096371210054782e-6)]
     ];
 
-    chanhull = ChanLowerConvexHull{eltype(subhullpoints[1])}(CCW, true, sortedby);
+    chanhull = ChanLowerConvexHull{eltype(subhullpoints[1])}(; collinear=true, sortedby);
     chanhull.subhulls = [lower_monotonechain(pts; collinear=true, sortedby=sortedby) for pts in subhullpoints];
 
     jarvishull = lower_jarvismarch(collect(Iterators.flatten(subhullpoints)); orientation=CCW, collinear=true, sortedby=sortedby)


### PR DESCRIPTION
  This is a broad freshening pass across the package — bug fixes, API completions, quality infrastructure, and
  documentation.

  ### Bug fixes

  - Fix `empty!` crash on Chan convex hulls (`UndefVarError: subhulls`)
  - Fix `jarvismarch!` returning a `HullList` instead of a hull when the upper hull has ≤ 1 point
  - Remove bare try/catch in `merge_hull_lists!` that silently swallowed all exceptions, including real bugs, and fell back to
  a slower path that was never needed on valid input

  ### API additions

  - Add value-based `removepoint!(hull, value)` (O(log n) via skip-list); works for regular and Chan hulls
  - Export non-mutating `mergehulls` and add a docstring
  - Extend `insidehull` to accept Chan hulls
  - Add `Base.hash` consistent with `==`, so hulls work correctly as Dict keys and Set elements
  - Add `Base.copy` as a true deep copy (fixes `mergehulls(h, others...)`, which previously threw MethodError)
  - Add `Base.eltype` / `Base.IteratorEltype` for `HullNodeIterator` and `PointNodeIterator`
  - Accept `AbstractMatrix` point input in entry points; forward config keywords
  - Move hull constructor config args from positional to keyword (breaking)
  - Fix `insidehull` inconsistencies for points along the hull boundary

  Quality and correctness

  - Replace reachable `@assert` with explicit throw so checks are never elided under optimization
  - Narrow `mergehulls!`/`mergehulls` to regular hull types, excluding Chan hulls (which lack .points); Chan inputs now get a
  MethodError at the call site instead of crashing inside
  - Replace splat in `jarvismarch` entry points with a loop to avoid the splat limit on large inputs
  - Mark immutable struct fields const; bump Julia compat to 1.10
  - Mark `HullNodeIterator` / `PointNodeIterator` public rather than exported (they expose internal node layouts; using
  `MutableConvexHulls` no longer binds the bare names) — breaking for code using them unqualified
  - Make imports explicit (replace wildcard using); add ExplicitImports.jl checks
  - Add Aqua.jl quality checks (ambiguities, stale deps, compat gaps, piracy)

  Tests

  - Coverage: 88.6% → 94.6%
  - Add test/test_generic_axes.jl verifying all `AbstractVector`-taking entry points work on `OffsetArray` and view inputs
  - Add `@test_logs` assertions confirming no fallback warning fires during normal merge operations
  - Fix test smells: broken inner-constructor assertion, missing .hull accessor, undefined T reference

  Documentation

  - Overhaul docs/: structured index.md with installation, concepts, and a tested quick-start jldoctest; new api.md with
  `@docs` blocks grouped by hull type, constructor, mutation, merging, membership, and node access; checkdocs=:exports added to makedocs
  - Add docstrings for all Chan hull types and remaining undocumented exported symbols
  - Add quick-start example to README; add JuliaHub badge and installation section
  - Fix broken `@ref` links in module docstring